### PR TITLE
GRAPH.COPY + GRAPH.CONSTRAINT

### DIFF
--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -130,7 +130,7 @@ class AsyncGraph(Graph):
             clone (str): Name of cloned graph
 
         Returns:
-            Graph: the cloned graph
+            AsyncGraph: the cloned graph
         """
 
         await self.execute_command(COPY_CMD, self._name, clone)

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -9,8 +9,10 @@ from falkordb.execution_plan import ExecutionPlan
 
 # procedures
 GRAPH_INDEXES = "DB.INDEXES"
+GRAPH_LIST_CONSTRAINTS = "DB.CONSTRAINTS"
 
 # commands
+COPY_CMD      = "GRAPH.COPY"
 QUERY_CMD     = "GRAPH.QUERY"
 DELETE_CMD    = "GRAPH.DELETE"
 EXPLAIN_CMD   = "GRAPH.EXPLAIN"
@@ -119,6 +121,20 @@ class AsyncGraph(Graph):
         """
 
         return await self._query(q, params=params, timeout=timeout, read_only=True)
+
+    async def copy(self, clone: str):
+        """
+        Creates a copy of graph
+
+        Args:
+            clone (str): Name of cloned graph
+
+        Returns:
+            Graph: the cloned graph
+        """
+
+        await self.execute_command(COPY_CMD, self._name, clone)
+        return AsyncGraph(self.client, clone)
 
     async def delete(self) -> None:
         """
@@ -497,3 +513,180 @@ class AsyncGraph(Graph):
         options = {'dimension': dim, 'similarityFunction': similarity_function}
         res = await self._create_typed_index("VECTOR", "EDGE", relation, *properties, options=options)
         return res
+
+    async def _create_constraint(self, constraint_type: str, entity_type: str, label: str, *properties):
+        """
+        Create a constraint
+        """
+
+        # GRAPH.CONSTRAINT CREATE key constraintType {NODE label | RELATIONSHIP reltype} PROPERTIES propCount prop [prop...]
+        return await self.execute_command("GRAPH.CONSTRAINT", "CREATE", self.name,
+                                    constraint_type, entity_type, label,
+                                    "PROPERTIES", len(properties), *properties)
+
+    async def create_node_unique_constraint(self, label: str, *properties):
+        """
+        Create node unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Note: unique constraints require a the existance of a range index
+        over the constraint properties, this function will create any missing range indices
+
+        Args:
+            label (str): Node label to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        # create required range indices
+        try:
+            await self.create_node_range_index(label, *properties)
+        except Exception:
+            pass
+
+        # create constraint
+        return await self._create_constraint("UNIQUE", "NODE", label, *properties)
+
+    async def create_edge_unique_constraint(self, relation: str, *properties):
+        """
+        Create edge unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Note: unique constraints require a the existance of a range index
+        over the constraint properties, this function will create any missing range indices
+
+        Args:
+            relation (str): Edge relationship-type to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        # create required range indices
+        try:
+            await self.create_edge_range_index(relation, *properties)
+        except Exception:
+            pass
+
+        return await self._create_constraint("UNIQUE", "RELATIONSHIP", relation, *properties)
+
+    async def create_node_mandatory_constraint(self, label: str, *properties):
+        """
+        Create node mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Args:
+            label (str): Node label to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        return await self._create_constraint("MANDATORY", "NODE", label, *properties)
+
+    async def create_edge_mandatory_constraint(self, relation: str, *properties):
+        """
+        Create edge mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Args:
+            relation (str): Edge relationship-type to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+        return await self._create_constraint("MANDATORY", "RELATIONSHIP", relation, *properties)
+
+    async def _drop_constraint(self, constraint_type: str, entity_type: str, label: str, *properties):
+        """
+        Drops a constraint
+
+        Args:
+        constraint_type (str): Type of constraint to drop
+        entity_type (str): Type of entity to drop constraint from
+        label (str): entity's label / relationship-type
+        properties: entity's properties to remove constraint from
+        """
+
+        return await self.execute_command("GRAPH.CONSTRAINT", "DROP", self.name,
+                                    constraint_type, entity_type, label,
+                                    "PROPERTIES", len(properties), *properties)
+
+    async def drop_node_unique_constraint(self, label: str, *properties):
+        """
+        Drop node unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Note: the constraint supporting range index is not removed
+
+        Args:
+            label (str): Node label to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        # drop constraint
+        return await self._drop_constraint("UNIQUE", "NODE", label, *properties)
+
+    async def drop_edge_unique_constraint(self, relation: str, *properties):
+        """
+        Drop edge unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Note: the constraint supporting range index is not removed
+
+        Args:
+            label (str): Edge relationship-type to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        return await self._drop_constraint("UNIQUE", "RELATIONSHIP", relation, *properties)
+
+    async def drop_node_mandatory_constraint(self, label: str, *properties):
+        """
+        Drop node mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Args:
+            label (str): Node label to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        return await self._drop_constraint("MANDATORY", "NODE", label, *properties)
+
+    async def drop_edge_mandatory_constraint(self, relation: str, *properties):
+        """
+        Drop edge mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Args:
+            label (str): Edge relationship-type to remove the constraint from
+            properties: properties to remove constraint from
+        """
+        return await self._drop_constraint("MANDATORY", "RELATIONSHIP", relation, *properties)
+
+    async def list_constraints(self) -> [Dict[str, object]]:
+        """
+        Lists graph's constraints
+
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html#listing-constraints
+
+        Returns:
+            [Dict[str, object]]: list of constraints
+        """
+
+        result = (await self.call_procedure(GRAPH_LIST_CONSTRAINTS)).result_set
+
+        constraints = []
+        for row in result:
+            constraints.append({"type":       row[0],
+                                "label":      row[1],
+                                "properties": row[2],
+                                "entitytype": row[3],
+                                "status":     row[4]})
+        return constraints
+

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -10,6 +10,7 @@ GRAPH_INDEXES          = "DB.INDEXES"
 GRAPH_LIST_CONSTRAINTS = "DB.CONSTRAINTS"
 
 # commands
+COPY_CMD      = "GRAPH.COPY"
 QUERY_CMD     = "GRAPH.QUERY"
 DELETE_CMD    = "GRAPH.DELETE"
 EXPLAIN_CMD   = "GRAPH.EXPLAIN"
@@ -142,7 +143,7 @@ class Graph():
             Graph: the cloned graph
         """
 
-        self.execute_command("GRAPH.COPY", self.name, clone)
+        self.execute_command(COPY_CMD, self.name, clone)
         return Graph(self.client, clone)
 
     def delete(self) -> None:

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -6,7 +6,8 @@ from .exceptions import SchemaVersionMismatchException
 from .helpers import quote_string, stringify_param_value
 
 # procedures
-GRAPH_INDEXES = "DB.INDEXES"
+GRAPH_INDEXES          = "DB.INDEXES"
+GRAPH_LIST_CONSTRAINTS = "DB.CONSTRAINTS"
 
 # commands
 QUERY_CMD     = "GRAPH.QUERY"
@@ -129,6 +130,20 @@ class Graph():
         """
 
         return self._query(q, params=params, timeout=timeout, read_only=True)
+
+    def copy(self, clone: str):
+        """
+        Creates a copy of graph
+
+        Args:
+            clone (str): Name of cloned graph
+
+        Returns:
+            Graph: the cloned graph
+        """
+
+        self.execute_command("GRAPH.COPY", self.name, clone)
+        return Graph(self.client, clone)
 
     def delete(self) -> None:
         """
@@ -523,3 +538,180 @@ class Graph():
         """
         options = {'dimension': dim, 'similarityFunction': similarity_function}
         return self._create_typed_index("VECTOR", "EDGE", relation, *properties, options=options)
+
+    def _create_constraint(self, constraint_type: str, entity_type: str, label: str, *properties):
+        """
+        Create a constraint
+        """
+
+        # GRAPH.CONSTRAINT CREATE key constraintType {NODE label | RELATIONSHIP reltype} PROPERTIES propCount prop [prop...]
+        return self.execute_command("GRAPH.CONSTRAINT", "CREATE", self.name,
+                                    constraint_type, entity_type, label,
+                                    "PROPERTIES", len(properties), *properties)
+
+    def create_node_unique_constraint(self, label: str, *properties):
+        """
+        Create node unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Note: unique constraints require a the existance of a range index
+        over the constraint properties, this function will create any missing range indices
+
+        Args:
+            label (str): Node label to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        # create required range indices
+        try:
+            self.create_node_range_index(label, *properties)
+        except Exception:
+            pass
+
+        # create constraint
+        return self._create_constraint("UNIQUE", "NODE", label, *properties)
+
+    def create_edge_unique_constraint(self, relation: str, *properties):
+        """
+        Create edge unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Note: unique constraints require a the existance of a range index
+        over the constraint properties, this function will create any missing range indices
+
+        Args:
+            relation (str): Edge relationship-type to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        # create required range indices
+        try:
+            self.create_edge_range_index(relation, *properties)
+        except Exception:
+            pass
+
+        return self._create_constraint("UNIQUE", "RELATIONSHIP", relation, *properties)
+
+    def create_node_mandatory_constraint(self, label: str, *properties):
+        """
+        Create node mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Args:
+            label (str): Node label to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+
+        return self._create_constraint("MANDATORY", "NODE", label, *properties)
+
+    def create_edge_mandatory_constraint(self, relation: str, *properties):
+        """
+        Create edge mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        The constraint is created asynchronously, use list constraints to pull on
+        constraint creation status
+
+        Args:
+            relation (str): Edge relationship-type to apply constraint to
+            properties: Variable number of property names to constrain
+        """
+        return self._create_constraint("MANDATORY", "RELATIONSHIP", relation, *properties)
+
+    def _drop_constraint(self, constraint_type: str, entity_type: str, label: str, *properties):
+        """
+        Drops a constraint
+
+        Args:
+        constraint_type (str): Type of constraint to drop
+        entity_type (str): Type of entity to drop constraint from
+        label (str): entity's label / relationship-type
+        properties: entity's properties to remove constraint from
+        """
+
+        return self.execute_command("GRAPH.CONSTRAINT", "DROP", self.name,
+                                    constraint_type, entity_type, label,
+                                    "PROPERTIES", len(properties), *properties)
+
+    def drop_node_unique_constraint(self, label: str, *properties):
+        """
+        Drop node unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Note: the constraint supporting range index is not removed
+
+        Args:
+            label (str): Node label to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        # drop constraint
+        return self._drop_constraint("UNIQUE", "NODE", label, *properties)
+
+    def drop_edge_unique_constraint(self, relation: str, *properties):
+        """
+        Drop edge unique constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Note: the constraint supporting range index is not removed
+
+        Args:
+            label (str): Edge relationship-type to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        return self._drop_constraint("UNIQUE", "RELATIONSHIP", relation, *properties)
+
+    def drop_node_mandatory_constraint(self, label: str, *properties):
+        """
+        Drop node mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Args:
+            label (str): Node label to remove the constraint from
+            properties: properties to remove constraint from
+        """
+
+        return self._drop_constraint("MANDATORY", "NODE", label, *properties)
+
+    def drop_edge_mandatory_constraint(self, relation: str, *properties):
+        """
+        Drop edge mandatory constraint
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html
+
+        Args:
+            label (str): Edge relationship-type to remove the constraint from
+            properties: properties to remove constraint from
+        """
+        return self._drop_constraint("MANDATORY", "RELATIONSHIP", relation, *properties)
+
+    def list_constraints(self) -> [Dict[str, object]]:
+        """
+        Lists graph's constraints
+
+        See: https://docs.falkordb.com/commands/graph.constraint-create.html#listing-constraints
+
+        Returns:
+            [Dict[str, object]]: list of constraints
+        """
+
+        result = self.call_procedure(GRAPH_LIST_CONSTRAINTS).result_set
+
+        constraints = []
+        for row in result:
+            constraints.append({"type":       row[0],
+                                "label":      row[1],
+                                "properties": row[2],
+                                "entitytype": row[3],
+                                "status":     row[4]})
+        return constraints
+

--- a/tests/test_async_constraints.py
+++ b/tests/test_async_constraints.py
@@ -1,0 +1,46 @@
+import pytest
+import asyncio
+from falkordb.asyncio import FalkorDB
+
+async def test_constraints():
+    db = FalkorDB(host='localhost', port=6379)
+    g = db.select_graph("async_constraints")
+
+    # create node constraints
+    await g.create_node_unique_constraint("Person", "name")
+    await g.create_node_mandatory_constraint("Person", "name")
+    await g.create_node_unique_constraint("Person", "v1", "v2")
+
+    # create edge constraints
+    await g.create_edge_unique_constraint("KNOWS", "since")
+    await g.create_edge_mandatory_constraint("KNOWS", "since")
+    await g.create_edge_unique_constraint("KNOWS", "v1", "v2")
+
+    constraints = await g.list_constraints()
+    assert(len(constraints) == 6)
+
+    # drop constraints
+    await g.drop_node_unique_constraint("Person", "name")
+    await g.drop_node_mandatory_constraint("Person", "name")
+    await g.drop_node_unique_constraint("Person", "v1", "v2")
+
+    await g.drop_edge_unique_constraint("KNOWS", "since")
+    await g.drop_edge_mandatory_constraint("KNOWS", "since")
+    await g.drop_edge_unique_constraint("KNOWS", "v1", "v2")
+
+    constraints = await g.list_constraints()
+    assert(len(constraints) == 0)
+
+async def test_create_existing_constraint():
+    # trying to create an existing constraint
+    db = FalkorDB(host='localhost', port=6379)
+    g = db.select_graph("async_constraints")
+
+    # create node constraints
+    await g.create_node_unique_constraint("Person", "name")
+    try:
+        await g.create_node_unique_constraint("Person", "name")
+        assert(False)
+    except Exception as e:
+        assert("Constraint already exists" == str(e))
+

--- a/tests/test_async_constraints.py
+++ b/tests/test_async_constraints.py
@@ -1,9 +1,12 @@
 import pytest
 import asyncio
 from falkordb.asyncio import FalkorDB
+from redis.asyncio import BlockingConnectionPool
 
+@pytest.mark.asyncio
 async def test_constraints():
-    db = FalkorDB(host='localhost', port=6379)
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
     g = db.select_graph("async_constraints")
 
     # create node constraints
@@ -31,9 +34,14 @@ async def test_constraints():
     constraints = await g.list_constraints()
     assert(len(constraints) == 0)
 
+    # close the connection pool
+    await pool.aclose()
+
+@pytest.mark.asyncio
 async def test_create_existing_constraint():
     # trying to create an existing constraint
-    db = FalkorDB(host='localhost', port=6379)
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
     g = db.select_graph("async_constraints")
 
     # create node constraints
@@ -44,3 +52,5 @@ async def test_create_existing_constraint():
     except Exception as e:
         assert("Constraint already exists" == str(e))
 
+    # close the connection pool
+    await pool.aclose()

--- a/tests/test_async_copy.py
+++ b/tests/test_async_copy.py
@@ -1,0 +1,65 @@
+import pytest
+import asyncio
+from falkordb.asyncio import FalkorDB
+
+async def test_graph_copy():
+    # create a simple graph and clone it
+    # make sure graphs are the same
+
+    db = FalkorDB(host='localhost', port=6379)
+    src = db.select_graph("async_src")
+
+    # create entities
+    await src.query("CREATE (:A {v:1})-[:R {v:2}]->(:B {v:3})")
+
+    # create index
+    await src.create_edge_range_index("A", "v")
+    await src.create_edge_range_index("R", "v")
+    await src.create_node_fulltext_index("B", "v")
+
+    # create constrain
+    await src.create_node_unique_constraint("A", "v")
+    await src.create_edge_unique_constraint("R", "v")
+
+    # clone graph
+    dest = await src.copy("async_dest")
+
+    # validate src and dest are the same
+    # validate entities
+    q = "MATCH (a) RETURN a ORDER BY ID(a)"
+    src_res  = (await src.query(q)).result_set
+    dest_res = (await dest.query(q)).result_set
+    assert(src_res == dest_res)
+
+    q = "MATCH ()-[e]->() RETURN e ORDER BY ID(e)"
+    src_res  = (await src.query(q)).result_set
+    dest_res = (await dest.query(q)).result_set
+    assert(src_res == dest_res)
+
+    # validate schema
+    src_res  = (await src.call_procedure("DB.LABELS")).result_set
+    dest_res = (await dest.call_procedure("DB.LABELS")).result_set
+    assert(src_res == dest_res)
+
+    src_res  = (await src.call_procedure("DB.PROPERTYKEYS")).result_set
+    dest_res = (await dest.call_procedure("DB.PROPERTYKEYS")).result_set
+    assert(src_res == dest_res)
+
+    src_res  = (await src.call_procedure("DB.RELATIONSHIPTYPES")).result_set
+    dest_res = (await dest.call_procedure("DB.RELATIONSHIPTYPES")).result_set
+    assert(src_res == dest_res)
+
+    # validate indices
+    q = """CALL DB.INDEXES()
+           YIELD label, properties, types, language, stopwords, entitytype, status
+           RETURN *
+           ORDER BY label, properties, types, language, stopwords, entitytype, status"""
+    src_res = (await src.query(q)).result_set
+    dest_res = (await dest.query(q)).result_set
+
+    assert(src_res == dest_res)
+
+    # validate constraints
+    src_res = await src.list_constraints()
+    dest_res = await dest.list_constraints()
+    assert(src_res == dest_res)

--- a/tests/test_async_copy.py
+++ b/tests/test_async_copy.py
@@ -1,13 +1,15 @@
 import pytest
 import asyncio
 from falkordb.asyncio import FalkorDB
+from redis.asyncio import BlockingConnectionPool
 
 @pytest.mark.asyncio
 async def test_graph_copy():
     # create a simple graph and clone it
     # make sure graphs are the same
 
-    db = FalkorDB(host='localhost', port=6379)
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
     src = db.select_graph("async_src")
 
     # create entities
@@ -64,3 +66,6 @@ async def test_graph_copy():
     src_res = await src.list_constraints()
     dest_res = await dest.list_constraints()
     assert(src_res == dest_res)
+
+    # close the connection pool
+    await pool.aclose()

--- a/tests/test_async_copy.py
+++ b/tests/test_async_copy.py
@@ -2,6 +2,7 @@ import pytest
 import asyncio
 from falkordb.asyncio import FalkorDB
 
+@pytest.mark.asyncio
 async def test_graph_copy():
     # create a simple graph and clone it
     # make sure graphs are the same

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -8,6 +8,7 @@ def client(request):
     return FalkorDB(host='localhost', port=6379)
 
 
+@pytest.mark.asyncio
 async def test_config(client):
     db = client
     config_name = "RESULTSET_SIZE"
@@ -37,6 +38,7 @@ async def test_config(client):
     with pytest.raises(Exception):
         await db.config_set(config_name, "invalid value")
 
+@pytest.mark.asyncio
 async def test_connect_via_url():
     # make sure we're able to connect via url
     db = FalkorDB.from_url("falkor://localhost:6379")

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -40,6 +40,6 @@ async def test_config(client):
 async def test_connect_via_url():
     # make sure we're able to connect via url
     db = FalkorDB.from_url("falkor://localhost:6379")
-    g = db.select_graph("g")
+    g = db.select_graph("async_db")
     one = (await g.query("RETURN 1")).result_set[0][0]
     assert one == 1

--- a/tests/test_async_explain.py
+++ b/tests/test_async_explain.py
@@ -8,6 +8,7 @@ async def client(request):
     return db.select_graph("async_explain")
 
 
+@pytest.mark.asyncio
 async def test_explain(client):
     g = client
 
@@ -28,6 +29,7 @@ async def test_explain(client):
     assert(unwind_op.name == 'Unwind')
     assert(len(unwind_op.children) == 0)
 
+@pytest.mark.asyncio
 async def test_cartesian_product_explain(client):
     g = client
     plan = await g.explain("MATCH (a), (b) RETURN *")
@@ -53,6 +55,7 @@ async def test_cartesian_product_explain(client):
     assert(scan_b_op.name == 'All Node Scan')
     assert(len(scan_b_op.children) == 0)
 
+@pytest.mark.asyncio
 async def test_merge(client):
     g = client
 

--- a/tests/test_async_explain.py
+++ b/tests/test_async_explain.py
@@ -1,16 +1,13 @@
 import pytest
 from falkordb.asyncio import FalkorDB
-
-
-@pytest.fixture
-async def client(request):
-    db = FalkorDB(host='localhost', port=6379)
-    return db.select_graph("async_explain")
+from redis.asyncio import BlockingConnectionPool
 
 
 @pytest.mark.asyncio
-async def test_explain(client):
-    g = client
+async def test_explain():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_explain")
 
     # run a single query to create the graph
     await g.query("RETURN 1")
@@ -29,9 +26,14 @@ async def test_explain(client):
     assert(unwind_op.name == 'Unwind')
     assert(len(unwind_op.children) == 0)
 
+    # close the connection pool
+    await pool.aclose()
+
 @pytest.mark.asyncio
-async def test_cartesian_product_explain(client):
-    g = client
+async def test_cartesian_product_explain():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_explain")
     plan = await g.explain("MATCH (a), (b) RETURN *")
 
     results_op = plan.structured_plan
@@ -55,9 +57,14 @@ async def test_cartesian_product_explain(client):
     assert(scan_b_op.name == 'All Node Scan')
     assert(len(scan_b_op.children) == 0)
 
+    # close the connection pool
+    await pool.aclose()
+
 @pytest.mark.asyncio
-async def test_merge(client):
-    g = client
+async def test_merge():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_explain")
 
     try:
         await g.create_node_range_index("person", "age")
@@ -96,3 +103,6 @@ async def test_merge(client):
     arg_op = merge_create_op.children[0]
     assert(arg_op.name == 'Argument')
     assert(len(arg_op.children) == 0)
+
+    # close the connection pool
+    await pool.aclose()

--- a/tests/test_async_explain.py
+++ b/tests/test_async_explain.py
@@ -5,7 +5,7 @@ from falkordb.asyncio import FalkorDB
 @pytest.fixture
 async def client(request):
     db = FalkorDB(host='localhost', port=6379)
-    return db.select_graph("explain")
+    return db.select_graph("async_explain")
 
 
 async def test_explain(client):

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -10,6 +10,7 @@ async def client(request):
     await db.flushdb()
     return db.select_graph("async_graph")
 
+@pytest.mark.asyncio
 async def test_graph_creation(client):
     graph = client
 
@@ -44,6 +45,7 @@ async def test_graph_creation(client):
     assert [1, 2.3, "4", True, False, None] == result.result_set[0][0]
 
 
+@pytest.mark.asyncio
 async def test_array_functions(client):
     graph = client
     query = """RETURN [0,1,2]"""
@@ -64,6 +66,7 @@ async def test_array_functions(client):
     assert [a] == result.result_set[0][0]
 
 
+@pytest.mark.asyncio
 async def test_path(client):
     graph  = client
     node0  = Node(alias="node0", node_id=0, labels="L1")
@@ -80,6 +83,7 @@ async def test_path(client):
     assert expected_results == result.result_set
 
 
+@pytest.mark.asyncio
 async def test_param(client):
     graph = client
     params = [1, 2.3, "str", True, False, None, [0, 1, 2], r"\" RETURN 1337 //"]
@@ -90,6 +94,7 @@ async def test_param(client):
         assert expected_results == result.result_set
 
 
+@pytest.mark.asyncio
 async def test_map(client):
     g = client
 
@@ -116,6 +121,7 @@ async def test_map(client):
     expected = { "src": src, "e": e, "dest": dest }
     assert actual == expected
 
+@pytest.mark.asyncio
 async def test_point(client):
     g = client
     query = "RETURN point({latitude: 32.070794860, longitude: 34.820751118})"
@@ -133,6 +139,7 @@ async def test_point(client):
     assert abs(actual["longitude"] - expected_lon) < 0.001
 
 
+@pytest.mark.asyncio
 async def test_index_response(client):
     g = client
     result_set = await g.query("CREATE INDEX ON :person(age)")
@@ -148,6 +155,7 @@ async def test_index_response(client):
         await g.query("DROP INDEX ON :person(age)")
 
 
+@pytest.mark.asyncio
 async def test_stringify_query_result(client):
     g = client
 
@@ -183,6 +191,7 @@ async def test_stringify_query_result(client):
     assert str(country) == """(:country{name:"Japan"})"""
 
 
+@pytest.mark.asyncio
 async def test_optional_match(client):
     # build a graph of form (a)-[R]->(b)
     src = Node(alias="src", node_id=0, labels="L1", properties={"value": "a"})
@@ -205,6 +214,7 @@ async def test_optional_match(client):
     assert expected_results == result.result_set
 
 
+@pytest.mark.asyncio
 async def test_cached_execution(client):
     g = client
 
@@ -215,6 +225,7 @@ async def test_cached_execution(client):
     assert result.cached_execution is True
 
 
+@pytest.mark.asyncio
 async def test_slowlog(client):
     g = client
     create_query = """CREATE (:Rider {name:'Valentino Rossi'})-[:rides]->(:Team {name:'Yamaha'}),
@@ -229,6 +240,7 @@ async def test_slowlog(client):
 
 
 @pytest.mark.xfail(strict=False)
+@pytest.mark.asyncio
 async def test_query_timeout(client):
     g = client
     # build a graph with 1000 nodes
@@ -243,6 +255,7 @@ async def test_query_timeout(client):
         assert False is False
 
 
+@pytest.mark.asyncio
 async def test_read_only_query(client):
     g = client
     with pytest.raises(Exception):
@@ -275,6 +288,7 @@ def _test_list_keys(client):
     assert result == []
 
 
+@pytest.mark.asyncio
 async def test_multi_label(client):
     g = client
 
@@ -299,6 +313,7 @@ async def test_multi_label(client):
         assert True
 
 
+@pytest.mark.asyncio
 async def test_cache_sync(client):
     pass
     return
@@ -371,6 +386,7 @@ async def test_cache_sync(client):
     assert A._relationship_types[1] == "R"
 
 
+@pytest.mark.asyncio
 async def test_execution_plan(client):
     g = client
     create_query = """CREATE
@@ -389,6 +405,7 @@ async def test_execution_plan(client):
     assert str(result) == expected
 
 
+@pytest.mark.asyncio
 async def test_explain(client):
     g = client
     # graph creation / population

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -2,17 +2,14 @@ import pytest
 from redis import ResponseError
 from falkordb.asyncio import FalkorDB
 from falkordb import Edge, Node, Path, Operation
+from redis.asyncio import BlockingConnectionPool
 
-
-@pytest.fixture
-async def client(request):
-    db = FalkorDB(host='localhost', port=6379)
-    await db.flushdb()
-    return db.select_graph("async_graph")
 
 @pytest.mark.asyncio
-async def test_graph_creation(client):
-    graph = client
+async def test_graph_creation():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    graph = db.select_graph("async_graph")
 
     john = Node(
         alias="p",
@@ -44,10 +41,17 @@ async def test_graph_creation(client):
     result = await graph.query(query)
     assert [1, 2.3, "4", True, False, None] == result.result_set[0][0]
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_array_functions(client):
-    graph = client
+async def test_array_functions():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    graph = db.select_graph("async_graph")
+
+    await graph.delete()
+
     query = """RETURN [0,1,2]"""
     result = await graph.query(query)
     assert [0, 1, 2] == result.result_set[0][0]
@@ -65,10 +69,17 @@ async def test_array_functions(client):
 
     assert [a] == result.result_set[0][0]
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_path(client):
-    graph  = client
+async def test_path():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    graph = db.select_graph("async_graph")
+
+    await graph.delete()
+
     node0  = Node(alias="node0", node_id=0, labels="L1")
     node1  = Node(alias="node1", node_id=1, labels="L1")
     edge01 = Edge(node0, "R1", node1, edge_id=0, properties={"value": 1})
@@ -82,10 +93,15 @@ async def test_path(client):
     result = await graph.query(query)
     assert expected_results == result.result_set
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_param(client):
-    graph = client
+async def test_param():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    graph = db.select_graph("async_graph")
+
     params = [1, 2.3, "str", True, False, None, [0, 1, 2], r"\" RETURN 1337 //"]
     query = "RETURN $param"
     for param in params:
@@ -93,10 +109,16 @@ async def test_param(client):
         expected_results = [[param]]
         assert expected_results == result.result_set
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_map(client):
-    g = client
+async def test_map():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
+    await g.delete()
 
     query = "RETURN {a:1, b:'str', c:NULL, d:[1,2,3], e:True, f:{x:1, y:2}}"
     actual = (await g.query(query)).result_set[0][0]
@@ -121,9 +143,15 @@ async def test_map(client):
     expected = { "src": src, "e": e, "dest": dest }
     assert actual == expected
 
+    # close the connection pool
+    await pool.aclose()
+
 @pytest.mark.asyncio
-async def test_point(client):
-    g = client
+async def test_point():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
     query = "RETURN point({latitude: 32.070794860, longitude: 34.820751118})"
     expected_lat = 32.070794860
     expected_lon = 34.820751118
@@ -138,10 +166,15 @@ async def test_point(client):
     assert abs(actual["latitude"] - expected_lat) < 0.001
     assert abs(actual["longitude"] - expected_lon) < 0.001
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_index_response(client):
-    g = client
+async def test_index_response():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
     result_set = await g.query("CREATE INDEX ON :person(age)")
     assert 1 == result_set.indices_created
 
@@ -154,10 +187,14 @@ async def test_index_response(client):
     with pytest.raises(ResponseError):
         await g.query("DROP INDEX ON :person(age)")
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_stringify_query_result(client):
-    g = client
+async def test_stringify_query_result():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
 
     john = Node(alias="a", labels="person",
                 properties={ "name": "John Doe", "age": 33, "gender": "male",
@@ -190,16 +227,23 @@ async def test_stringify_query_result(client):
     assert str(visit) == """()-[:visited{purpose:"pleasure"}]->()"""
     assert str(country) == """(:country{name:"Japan"})"""
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_optional_match(client):
+async def test_optional_match():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
+    await g.delete()
+
     # build a graph of form (a)-[R]->(b)
     src = Node(alias="src", node_id=0, labels="L1", properties={"value": "a"})
     dest = Node(alias="dest", node_id=1, labels="L1", properties={"value": "b"})
 
     e = Edge(src, "R", dest, edge_id=0)
 
-    g = client
     await g.query(f"CREATE {src}, {dest}, {e}")
 
     # issue a query that collects all outgoing edges from both nodes
@@ -213,10 +257,14 @@ async def test_optional_match(client):
     result = await g.query(query)
     assert expected_results == result.result_set
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_cached_execution(client):
-    g = client
+async def test_cached_execution():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
 
     result = await g.query("RETURN $param", {"param": 0})
     assert result.cached_execution is False
@@ -224,10 +272,17 @@ async def test_cached_execution(client):
     result = await g.query("RETURN $param", {"param": 0})
     assert result.cached_execution is True
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_slowlog(client):
-    g = client
+async def test_slowlog():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
+    await g.delete()
+
     create_query = """CREATE (:Rider {name:'Valentino Rossi'})-[:rides]->(:Team {name:'Yamaha'}),
                              (:Rider {name:'Dani Pedrosa'})-[:rides]->(:Team {name:'Honda'}),
                              (:Rider {name:'Andrea Dovizioso'})-[:rides]->(:Team {name:'Ducati'})"""
@@ -238,11 +293,16 @@ async def test_slowlog(client):
     assert results[0][1] == "GRAPH.QUERY"
     assert results[0][2] == create_query
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.xfail(strict=False)
 @pytest.mark.asyncio
-async def test_query_timeout(client):
-    g = client
+async def test_query_timeout():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
     # build a graph with 1000 nodes
     await g.query("UNWIND range(0, 1000) as val CREATE ({v: val})")
     # issue a long-running query with a 1-millisecond timeout
@@ -254,43 +314,31 @@ async def test_query_timeout(client):
         await g.query("RETURN 1", timeout="str")
         assert False is False
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_read_only_query(client):
-    g = client
+async def test_read_only_query():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
     with pytest.raises(Exception):
         # issue a write query, specifying read-only true
         # call should fail
         await g.query("CREATE ()", read_only=True)
         assert False is False
 
-
-def _test_list_keys(client):
-    g = client
-    result = g.list_keys()
-    assert result == []
-
-    client.graph("G").query("RETURN 1")
-    result = client.graph().list_keys()
-    assert result == ["G"]
-
-    client.graph("X").query("RETURN 1")
-    result = client.graph().list_keys()
-    assert result == ["G", "X"]
-
-    client.delete("G")
-    client.rename("X", "Z")
-    result = client.graph().list_keys()
-    assert result == ["Z"]
-
-    client.delete("Z")
-    result = client.graph().list_keys()
-    assert result == []
-
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_multi_label(client):
-    g = client
+async def test_multi_label():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
+    await g.delete()
 
     node = Node(labels=["l", "ll"])
     await g.query(f"CREATE {node}")
@@ -312,83 +360,15 @@ async def test_multi_label(client):
     except AssertionError:
         assert True
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_cache_sync(client):
-    pass
-    return
-    # This test verifies that client internal graph schema cache stays
-    # in sync with the graph schema
-    #
-    # Client B will try to get Client A out of sync by:
-    # 1. deleting the graph
-    # 2. reconstructing the graph in a different order, this will casuse
-    #    a differance in the current mapping between string IDs and the
-    #    mapping Client A is aware of
-    #
-    # Client A should pick up on the changes by comparing graph versions
-    # and resyncing its cache.
+async def test_execution_plan():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
 
-    A = client.graph("cache-sync")
-    B = client.graph("cache-sync")
-
-    # Build order:
-    # 1. introduce label 'L' and 'K'
-    # 2. introduce attribute 'x' and 'q'
-    # 3. introduce relationship-type 'R' and 'S'
-
-    await A.query("CREATE (:L)")
-    await B.query("CREATE (:K)")
-    await A.query("MATCH (n) SET n.x = 1")
-    await B.query("MATCH (n) SET n.q = 1")
-    await A.query("MATCH (n) CREATE (n)-[:R]->()")
-    await B.query("MATCH (n) CREATE (n)-[:S]->()")
-
-    # Cause client A to populate its cache
-    await A.query("MATCH (n)-[e]->() RETURN n, e")
-
-    assert len(A._labels) == 2
-    assert len(A._properties) == 2
-    assert len(A._relationship_types) == 2
-    assert A._labels[0] == "L"
-    assert A._labels[1] == "K"
-    assert A._properties[0] == "x"
-    assert A._properties[1] == "q"
-    assert A._relationship_types[0] == "R"
-    assert A._relationship_types[1] == "S"
-
-    # Have client B reconstruct the graph in a different order.
-    B.delete()
-
-    # Build order:
-    # 1. introduce relationship-type 'R'
-    # 2. introduce label 'L'
-    # 3. introduce attribute 'x'
-    await B.query("CREATE ()-[:S]->()")
-    await B.query("CREATE ()-[:R]->()")
-    await B.query("CREATE (:K)")
-    await B.query("CREATE (:L)")
-    await B.query("MATCH (n) SET n.q = 1")
-    await B.query("MATCH (n) SET n.x = 1")
-
-    # A's internal cached mapping is now out of sync
-    # issue a query and make sure A's cache is synced.
-    await A.query("MATCH (n)-[e]->() RETURN n, e")
-
-    assert len(A._labels) == 2
-    assert len(A._properties) == 2
-    assert len(A._relationship_types) == 2
-    assert A._labels[0] == "K"
-    assert A._labels[1] == "L"
-    assert A._properties[0] == "q"
-    assert A._properties[1] == "x"
-    assert A._relationship_types[0] == "S"
-    assert A._relationship_types[1] == "R"
-
-
-@pytest.mark.asyncio
-async def test_execution_plan(client):
-    g = client
     create_query = """CREATE
                       (:Rider {name:'Valentino Rossi'})-[:rides]->(:Team {name:'Yamaha'}),
                       (:Rider {name:'Dani Pedrosa'})-[:rides]->(:Team {name:'Honda'}),
@@ -404,10 +384,15 @@ async def test_execution_plan(client):
     expected = "Results\n    Project\n        Conditional Traverse | (t)->(r:Rider)\n            Filter\n                Node By Label Scan | (t:Team)"
     assert str(result) == expected
 
+    # close the connection pool
+    await pool.aclose()
 
 @pytest.mark.asyncio
-async def test_explain(client):
-    g = client
+async def test_explain():
+    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    db = FalkorDB(connection_pool=pool)
+    g = db.select_graph("async_graph")
+
     # graph creation / population
     create_query = """CREATE
                       (:Rider {name:'Valentino Rossi'})-[:rides]->(:Team {name:'Yamaha'}),
@@ -487,3 +472,6 @@ Project
     )
 
     assert result.structured_plan == expected
+
+    # close the connection pool
+    await pool.aclose()

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -8,7 +8,7 @@ from falkordb import Edge, Node, Path, Operation
 async def client(request):
     db = FalkorDB(host='localhost', port=6379)
     await db.flushdb()
-    return db.select_graph("g")
+    return db.select_graph("async_graph")
 
 async def test_graph_creation(client):
     graph = client

--- a/tests/test_async_indices.py
+++ b/tests/test_async_indices.py
@@ -17,6 +17,7 @@ async def client(request):
     await db.flushdb()
     return db.select_graph("async_indices")
 
+@pytest.mark.asyncio
 async def test_node_index_creation(client):
     graph = client
     lbl = "N"
@@ -90,6 +91,7 @@ async def test_node_index_creation(client):
     assert(index.types['desc'] == ['VECTOR'])
     assert(index.entity_type   == 'NODE')
 
+@pytest.mark.asyncio
 async def test_edge_index_creation(client):
     graph = client
     rel = "R"
@@ -163,6 +165,7 @@ async def test_edge_index_creation(client):
     assert(index.types['desc'] == ['VECTOR'])
     assert(index.entity_type   == 'RELATIONSHIP')
 
+@pytest.mark.asyncio
 async def test_node_index_drop(client):
     graph = client
 
@@ -222,6 +225,7 @@ async def test_node_index_drop(client):
     res = await graph.list_indices()
     assert(len(res.result_set) == 0)
 
+@pytest.mark.asyncio
 async def test_edge_index_drop(client):
     graph = client
 

--- a/tests/test_async_indices.py
+++ b/tests/test_async_indices.py
@@ -15,7 +15,7 @@ class Index():
 async def client(request):
     db = FalkorDB(host='localhost', port=6379)
     await db.flushdb()
-    return db.select_graph("g")
+    return db.select_graph("async_indices")
 
 async def test_node_index_creation(client):
     graph = client

--- a/tests/test_async_profile.py
+++ b/tests/test_async_profile.py
@@ -5,7 +5,7 @@ from falkordb.asyncio import FalkorDB
 @pytest.fixture
 def client(request):
     db = FalkorDB(host='localhost', port=6379)
-    return db.select_graph("profile")
+    return db.select_graph("async_profile")
 
 async def test_profile(client):
     g = client

--- a/tests/test_async_profile.py
+++ b/tests/test_async_profile.py
@@ -7,6 +7,7 @@ def client(request):
     db = FalkorDB(host='localhost', port=6379)
     return db.select_graph("async_profile")
 
+@pytest.mark.asyncio
 async def test_profile(client):
     g = client
     plan = await g.profile("UNWIND range(0, 3) AS x RETURN x")
@@ -26,6 +27,7 @@ async def test_profile(client):
     assert(len(unwind_op.children) == 0)
     assert(unwind_op.profile_stats.records_produced == 4)
 
+@pytest.mark.asyncio
 async def test_cartesian_product_profile(client):
     g = client
     plan = await g.profile("MATCH (a), (b) RETURN *")

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,46 @@
+import pytest
+from redis import ResponseError
+from falkordb import FalkorDB
+
+def test_constraints():
+    db = FalkorDB(host='localhost', port=6379)
+    g = db.select_graph("constraints")
+
+    # create node constraints
+    g.create_node_unique_constraint("Person", "name")
+    g.create_node_mandatory_constraint("Person", "name")
+    g.create_node_unique_constraint("Person", "v1", "v2")
+
+    # create edge constraints
+    g.create_edge_unique_constraint("KNOWS", "since")
+    g.create_edge_mandatory_constraint("KNOWS", "since")
+    g.create_edge_unique_constraint("KNOWS", "v1", "v2")
+
+    constraints = g.list_constraints()
+    assert(len(constraints) == 6)
+
+    # drop constraints
+    g.drop_node_unique_constraint("Person", "name")
+    g.drop_node_mandatory_constraint("Person", "name")
+    g.drop_node_unique_constraint("Person", "v1", "v2")
+
+    g.drop_edge_unique_constraint("KNOWS", "since")
+    g.drop_edge_mandatory_constraint("KNOWS", "since")
+    g.drop_edge_unique_constraint("KNOWS", "v1", "v2")
+
+    constraints = g.list_constraints()
+    assert(len(constraints) == 0)
+
+def test_create_existing_constraint():
+    # trying to create an existing constraint
+    db = FalkorDB(host='localhost', port=6379)
+    g = db.select_graph("constraints")
+
+    # create node constraints
+    g.create_node_unique_constraint("Person", "name")
+    try:
+        g.create_node_unique_constraint("Person", "name")
+        assert(False)
+    except Exception as e:
+        assert("Constraint already exists" == str(e))
+

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,65 @@
+import pytest
+from redis import ResponseError
+from falkordb import FalkorDB
+
+def test_graph_copy():
+    # create a simple graph and clone it
+    # make sure graphs are the same
+
+    db = FalkorDB(host='localhost', port=6379)
+    src = db.select_graph("src")
+
+    # create entities
+    src.query("CREATE (:A {v:1})-[:R {v:2}]->(:B {v:3})")
+
+    # create index
+    src.create_edge_range_index("A", "v")
+    src.create_edge_range_index("R", "v")
+    src.create_node_fulltext_index("B", "v")
+
+    # create constrain
+    src.create_node_unique_constraint("A", "v")
+    src.create_edge_unique_constraint("R", "v")
+
+    # clone graph
+    dest = src.copy("dest")
+
+    # validate src and dest are the same
+    # validate entities
+    q = "MATCH (a) RETURN a ORDER BY ID(a)"
+    src_res  = src.query(q).result_set
+    dest_res = dest.query(q).result_set
+    assert(src_res == dest_res)
+
+    q = "MATCH ()-[e]->() RETURN e ORDER BY ID(e)"
+    src_res  = src.query(q).result_set
+    dest_res = dest.query(q).result_set
+    assert(src_res == dest_res)
+
+    # validate schema
+    src_res  = src.call_procedure("DB.LABELS").result_set
+    dest_res = dest.call_procedure("DB.LABELS").result_set
+    assert(src_res == dest_res)
+
+    src_res  = src.call_procedure("DB.PROPERTYKEYS").result_set
+    dest_res = dest.call_procedure("DB.PROPERTYKEYS").result_set
+    assert(src_res == dest_res)
+
+    src_res  = src.call_procedure("DB.RELATIONSHIPTYPES").result_set
+    dest_res = dest.call_procedure("DB.RELATIONSHIPTYPES").result_set
+    assert(src_res == dest_res)
+
+    # validate indices
+    q = """CALL DB.INDEXES()
+           YIELD label, properties, types, language, stopwords, entitytype, status
+           RETURN *
+           ORDER BY label, properties, types, language, stopwords, entitytype, status"""
+    src_res = src.query(q).result_set
+    dest_res = dest.query(q).result_set
+
+    assert(src_res == dest_res)
+
+    # validate constraints
+    src_res = src.list_constraints()
+    dest_res = dest.list_constraints()
+    assert(src_res == dest_res)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,5 +1,4 @@
 import pytest
-from redis import ResponseError
 from falkordb import FalkorDB
 
 def test_graph_copy():
@@ -7,7 +6,7 @@ def test_graph_copy():
     # make sure graphs are the same
 
     db = FalkorDB(host='localhost', port=6379)
-    src = db.select_graph("src")
+    src = db.select_graph("copy_src")
 
     # create entities
     src.query("CREATE (:A {v:1})-[:R {v:2}]->(:B {v:3})")
@@ -22,7 +21,7 @@ def test_graph_copy():
     src.create_edge_unique_constraint("R", "v")
 
     # clone graph
-    dest = src.copy("dest")
+    dest = src.copy("copy_dest")
 
     # validate src and dest are the same
     # validate entities

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -39,6 +39,6 @@ def test_config(client):
 def test_connect_via_url():
     # make sure we're able to connect via url
     db = FalkorDB.from_url("falkor://localhost:6379")
-    g = db.select_graph("g")
+    g = db.select_graph("db")
     one = g.query("RETURN 1").result_set[0][0]
     assert one == 1

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,7 @@ from falkordb import FalkorDB, Edge, Node, Path, Operation
 def client(request):
     db = FalkorDB(host='localhost', port=6379)
     db.flushdb()
-    return db.select_graph("g")
+    return db.select_graph("graph")
 
 def test_graph_creation(client):
     graph = client

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,13 +1,13 @@
 import pytest
 from redis import ResponseError
-from falkordb import FalkorDB, Graph, Edge, Node, Path, Operation
+from falkordb import FalkorDB, Edge, Node, Path, Operation
 
 
 @pytest.fixture
 def client(request):
     db = FalkorDB(host='localhost', port=6379)
     db.flushdb()
-    return Graph(db, "g")
+    return db.select_graph("g")
 
 def test_graph_creation(client):
     graph = client

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -14,7 +14,7 @@ class Index():
 def client(request):
     db = FalkorDB(host='localhost', port=6379)
     db.flushdb()
-    return db.select_graph("g")
+    return db.select_graph("indices")
 
 def test_node_index_creation(client):
     graph = client

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1,6 +1,6 @@
 import pytest
 from redis import ResponseError
-from falkordb import FalkorDB, Graph, Edge, Node
+from falkordb import FalkorDB
 from collections import OrderedDict
 
 class Index():
@@ -14,7 +14,7 @@ class Index():
 def client(request):
     db = FalkorDB(host='localhost', port=6379)
     db.flushdb()
-    return Graph(db, "g")
+    return db.select_graph("g")
 
 def test_node_index_creation(client):
     graph = client

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -4,12 +4,12 @@ from falkordb import FalkorDB
 
 @pytest.fixture
 def client(request):
-    return FalkorDB(host='localhost', port=6379)
+    db = FalkorDB(host='localhost', port=6379)
+    return db.select_graph("profile")
 
 
 def test_profile(client):
-    db = client
-    g = db.select_graph("profile")
+    g = client
     plan = g.profile("UNWIND range(0, 3) AS x RETURN x")
 
     results_op = plan.structured_plan
@@ -28,8 +28,7 @@ def test_profile(client):
     assert(unwind_op.profile_stats.records_produced == 4)
 
 def test_cartesian_product_profile(client):
-    db = client
-    g = db.select_graph("profile")
+    g = client
     plan = g.profile("MATCH (a), (b) RETURN *")
 
     results_op = plan.structured_plan


### PR DESCRIPTION
Add support for both `GRAPH.COPY` and `GARPH.CONSTRAINT`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new graph operations for asynchronous management of unique and mandatory constraints for nodes and edges.
	- Added the ability to create a copy of a graph, enhancing data management capabilities.

- **Tests**
	- Added new test cases for asynchronous operations, including creating, listing, and dropping constraints, as well as copying graphs.
	- Updated existing tests to reflect changes in graph selection, emphasizing a shift towards asynchronous functionality in various graph operations.

- **Refactor**
	- Updated graph selection methodology in test suites to align with new asynchronous capabilities and naming conventions, ensuring more accurate and relevant test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->