### PR TITLE
min required python version 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.10', '3.11']
+        python: ['3.8', '3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -1,6 +1,6 @@
-from typing import List
-from .graph import AsyncGraph
 import redis.asyncio as redis
+from .graph import AsyncGraph
+from typing import List, Union
 
 # config command
 LIST_CMD   = "GRAPH.LIST"
@@ -148,7 +148,7 @@ class FalkorDB():
 
         return await self.connection.execute_command(LIST_CMD)
 
-    async def config_get(self, name: str) -> int | str:
+    async def config_get(self, name: str) -> Union[int, str]:
         """
         Retrieve a DB level configuration.
         For a list of available configurations see: https://docs.falkordb.com/configuration.html#falkordb-configuration-parameters

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -1,6 +1,6 @@
-from typing import List
 import redis
 from .graph import Graph
+from typing import List, Union
 
 # config command
 LIST_CMD   = "GRAPH.LIST"
@@ -161,7 +161,7 @@ class FalkorDB():
 
         return self.connection.execute_command(LIST_CMD)
 
-    def config_get(self, name: str) -> int | str:
+    def config_get(self, name: str) -> Union[int, str]:
         """
         Retrieve a DB level configuration.
         For a list of available configurations see: https://docs.falkordb.com/configuration.html#falkordb-configuration-parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ['FalkorDB', 'GraphDB', 'Cypher']
 packages = [{include = "falkordb"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 redis = "^5.0.1"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Resolves #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the required Python version specification to `>= 3.8` in project documentation.
	- Expanded the matrix of Python versions in the GitHub Actions workflow to include versions `3.8`, `3.10`, and `3.11`.
	- Adjusted import statements and type hints in the `falkordb.py` file for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->