### PR TITLE
feat: add common class properties to QueryResult class

### DIFF
--- a/falkordb/query_result.py
+++ b/falkordb/query_result.py
@@ -7,6 +7,7 @@ from redis import ResponseError
 
 from .edge import Edge
 from .node import Node
+from .graph import Graph
 from .path import Path
 from .exceptions import SchemaVersionMismatchException
 
@@ -336,9 +337,9 @@ class QueryResult:
             graph: The graph on which the query was executed.
             response: The response from the server.
         """
-        self.graph      = graph
-        self.header     = []
-        self.result_set = []
+        self._graph      = graph
+        self._header     = []
+        self._result_set = []
         self._raw_stats = []
 
         # in case of an error, an exception will be raised
@@ -365,7 +366,7 @@ class QueryResult:
             error = response[0]
             if str(error) == "version mismatch":
                 version = response[1]
-                error = VersionMismatchException(version)
+                error = SchemaVersionMismatchException(version)
             raise error
 
         # if we encountered a run-time error, the last response
@@ -380,13 +381,13 @@ class QueryResult:
         Args:
             raw_result_set: The raw result set from the server.
         """
-        self.header = self.__parse_header(raw_result_set)
+        self._header = self.__parse_header(raw_result_set)
 
         # empty header
-        if len(self.header) == 0:
+        if len(self._header) == 0:
             return
 
-        self.result_set = self.__parse_records(raw_result_set)
+        self._result_set = self.__parse_records(raw_result_set)
 
     def __get_statistics(self, s):
         """
@@ -429,11 +430,41 @@ class QueryResult:
             list: A list of records.
         """
         records = [
-            [parse_scalar(cell, self.graph) for cell in row]
+            [parse_scalar(cell, self._graph) for cell in row]
             for row in raw_result_set[1]
         ]
 
         return records
+
+    @property
+    def graph(self) -> Graph:
+        """
+        Get the graph on which the query was executed.
+
+        Returns:
+            Graph: The original graph.
+        """
+        return self._graph
+
+    @property
+    def header(self) -> list:
+        """
+        Get the header of the result.
+
+        Returns:
+            list: An array of column name/column type pairs.
+        """
+        return self._header
+
+    @property
+    def result_set(self) -> list:
+        """
+        Get a list of the results from a query.
+
+        Returns:
+            list: A list of each row returned from a query.
+        """
+        return self._result_set
 
     @property
     def labels_added(self) -> int:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,11 +42,18 @@ def test_connect_via_url():
     # just host
     db = FalkorDB.from_url("falkor://localhost")
     g = db.select_graph("db")
-    one = g.query("RETURN 1").result_set[0][0]
+    qr = g.query("RETURN 1")
+    one = qr.result_set[0][0]
+    qr_g = qr.graph
     assert one == 1
+    assert g.name == qr_g.name
 
     # host & Port
     db = FalkorDB.from_url("falkor://localhost:6379")
     g = db.select_graph("db")
-    one = g.query("RETURN 1").result_set[0][0]
+    qr = g.query("RETURN 1")
+    one = qr.result_set[0][0]
+    header = qr.header
     assert one == 1
+    assert header[0][0] == 1
+    assert header[0][1] == '1'


### PR DESCRIPTION
Add property to the `QueryResult` class for both the header and result_set data objects. This was identified in #101 as a possible way to help improve clarity in the generated docs for how to actually use the result from the query.

Also fix bug where `VersionMismatchException` was used instead of `SchemaVersionMismatchException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for version mismatches by raising a more specific exception when a schema version mismatch occurs.

- **Tests**
  - Enhanced tests to verify that query results include correct graph names and headers, providing more comprehensive validation of query metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->