### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-py/security/code-scanning/2](https://github.com/FalkorDB/falkordb-py/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the job(s). The best practice is to add this block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For most test workflows that only check out code and upload coverage, `contents: read` is sufficient. If a step requires more (e.g., uploading coverage to Codecov), consult the action's documentation, but most often `contents: read` suffices. The change should be made at the top of `.github/workflows/test.yml`, after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
