### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,5 +1,7 @@
 # Run this job on tagging
 name: Release to PYPI
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-py/security/code-scanning/1](https://github.com/FalkorDB/falkordb-py/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and publishes to PyPI (using a secret), it does not need write access to the repository. The best fix is to add `permissions: contents: read` at the top level of the workflow, just after the `name` field and before `on`. This ensures all jobs in the workflow inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
