### PR TITLE
Rename exception to SchemaVersionMismatchException

### DIFF
--- a/falkordb/asyncio/query_result.py
+++ b/falkordb/asyncio/query_result.py
@@ -401,7 +401,7 @@ class QueryResult:
             error = response[0]
             if str(error) == "version mismatch":
                 version = response[1]
-                error = VersionMismatchException(version)
+                error = SchemaVersionMismatchException(version)
             raise error
 
         # if we encountered a run-time error, the last response


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema version mismatch errors now report the correct exception type when detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->