### PR TITLE
Add id-token permission for PYPI release workflow

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -2,6 +2,7 @@
 name: Release to PYPI
 permissions:
   contents: read
+  id-token: write
 on:
   push:
     tags:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security in package publishing workflow by enabling OIDC-based authentication for improved credential handling during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->