### PR TITLE
Stabilize async and cluster behavior across clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ falkordb/
   sentinel.py        # Redis Sentinel support
   _version.py        # Package version via importlib.metadata
   asyncio/           # Async mirror (see below)
+    sentinel.py      # Async Redis Sentinel support
   lite/              # Lightweight variant
 tests/
   test_*.py          # Sync tests
@@ -86,6 +87,7 @@ When modifying sync code, always check if the async counterpart needs the same c
 - `FalkorDB` wraps a `redis.Redis` (or `redis.asyncio.Redis`) connection
 - `Graph` receives the client and delegates commands via `client.execute_command()`
 - Graph commands are plain Redis commands: `GRAPH.QUERY`, `GRAPH.RO_QUERY`, `GRAPH.DELETE`, `GRAPH.EXPLAIN`, `GRAPH.PROFILE`, `GRAPH.COPY`, `GRAPH.LIST`, `GRAPH.CONFIG`
+- Client initialization supports explicit `topology_mode` (`auto`, `standalone`, `cluster`, `sentinel`) for deterministic connection behavior in HA and test environments
 
 ### Graph Model
 - `Node`, `Edge`, `Path` are lightweight data classes returned inside `QueryResult`

--- a/README.md
+++ b/README.md
@@ -97,3 +97,31 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+### Topology mode selection
+
+By default, the client uses `topology_mode="auto"` to detect standalone, cluster, or sentinel deployments.
+You can force the mode explicitly when you want deterministic initialization behavior.
+
+```python
+from falkordb import FalkorDB
+
+# force standalone behavior (skip auto probing)
+db = FalkorDB(host="localhost", port=6379, topology_mode="standalone")
+
+# force cluster behavior
+cluster_db = FalkorDB(
+    host="localhost",
+    port=6379,
+    topology_mode="cluster",
+    startup_nodes=None,
+)
+
+# force sentinel behavior (recommended to provide a service name)
+sentinel_db = FalkorDB(
+    host="localhost",
+    port=26379,
+    topology_mode="sentinel",
+    sentinel_service_name="mymaster",
+)
+```

--- a/falkordb/asyncio/cluster.py
+++ b/falkordb/asyncio/cluster.py
@@ -1,26 +1,99 @@
 import socket
+from typing import cast
 
 import redis as sync_redis  # type: ignore[import-not-found]
 import redis.asyncio as redis  # type: ignore[import-not-found]
 import redis.exceptions as redis_exceptions  # type: ignore[import-not-found]
 from redis.asyncio.cluster import RedisCluster  # type: ignore[import-not-found]
 
+ASYNC_CLUSTER_SUPPORTED_KWARGS = {
+    "cache",
+    "cache_config",
+    "client_name",
+    "credential_provider",
+    "encoding",
+    "encoding_errors",
+    "event_dispatcher",
+    "health_check_interval",
+    "lib_name",
+    "lib_version",
+    "load_balancing_strategy",
+    "max_connections",
+    "path",
+    "policy_resolver",
+    "protocol",
+    "socket_connect_timeout",
+    "socket_keepalive",
+    "socket_keepalive_options",
+    "socket_timeout",
+    "ssl_ca_certs",
+    "ssl_ca_data",
+    "ssl_cert_reqs",
+    "ssl_certfile",
+    "ssl_check_hostname",
+    "ssl_ciphers",
+    "ssl_exclude_verify_flags",
+    "ssl_include_verify_flags",
+    "ssl_keyfile",
+    "ssl_min_version",
+}
+
+ASYNC_PROBE_KWARGS = {
+    "client_name",
+    "credential_provider",
+    "db",
+    "host",
+    "password",
+    "path",
+    "port",
+    "protocol",
+    "socket_connect_timeout",
+    "socket_keepalive",
+    "socket_keepalive_options",
+    "socket_timeout",
+    "ssl",
+    "ssl_ca_certs",
+    "ssl_ca_data",
+    "ssl_cert_reqs",
+    "ssl_check_hostname",
+    "ssl_certfile",
+    "ssl_keyfile",
+    "username",
+}
+
+
+def _is_ssl_connection(pool) -> bool:
+    try:
+        return issubclass(pool.connection_class, redis.SSLConnection)
+    except TypeError:
+        return pool.connection_class is redis.SSLConnection
+
+
+def _probe_kwargs(kwargs):
+    probe_kwargs = {
+        key: value for key, value in kwargs.items() if key in ASYNC_PROBE_KWARGS
+    }
+    probe_kwargs["decode_responses"] = True
+    return probe_kwargs
+
 
 # detect if a connection is a cluster
 def Is_Cluster(conn: redis.Redis):
-
     pool = conn.connection_pool
     kwargs = pool.connection_kwargs.copy()
 
     # Check if the connection is using SSL and add it
-    # this propery is not kept in the connection_kwargs
-    kwargs["ssl"] = pool.connection_class is redis.SSLConnection
+    # this property is not kept in the connection_kwargs
+    kwargs["ssl"] = _is_ssl_connection(pool)
 
     # Create a synchronous Redis client with the same parameters
     # as the connection pool just to keep Is_Cluster synchronous
-    info = sync_redis.Redis(**kwargs).info(section="server")
-
-    return "redis_mode" in info and info["redis_mode"] == "cluster"
+    probe = sync_redis.Redis(**_probe_kwargs(kwargs))
+    try:
+        info = cast(dict, probe.info(section="server"))
+    finally:
+        probe.close()
+    return info.get("redis_mode") == "cluster"
 
 
 # create a cluster connection from a Redis connection
@@ -32,13 +105,15 @@ def Cluster_Conn(
     require_full_coverage=False,
     reinitialize_steps=5,
     read_from_replicas=False,
+    dynamic_startup_nodes=True,
+    url=None,
     address_remap=None,
 ):
-    connection_kwargs = conn.connection_pool.connection_kwargs
-    host = connection_kwargs.pop("host")
-    port = connection_kwargs.pop("port")
-    username = connection_kwargs.pop("username")
-    password = connection_kwargs.pop("password")
+    connection_kwargs = conn.connection_pool.connection_kwargs.copy()
+    host = connection_kwargs.pop("host", None)
+    port = connection_kwargs.pop("port", None)
+    username = connection_kwargs.pop("username", None)
+    password = connection_kwargs.pop("password", None)
 
     retry = connection_kwargs.pop("retry", None)
     retry_on_error = connection_kwargs.pop(
@@ -51,6 +126,15 @@ def Cluster_Conn(
             redis_exceptions.ConnectionError,
         ],
     )
+    connection_kwargs.pop("connection_pool", None)
+    connection_kwargs.pop("db", None)
+    connection_kwargs.pop("decode_responses", None)
+
+    cluster_kwargs = {
+        key: value
+        for key, value in connection_kwargs.items()
+        if key in ASYNC_CLUSTER_SUPPORTED_KWARGS
+    }
     return RedisCluster(
         host=host,
         port=port,
@@ -63,7 +147,9 @@ def Cluster_Conn(
         require_full_coverage=require_full_coverage,
         reinitialize_steps=reinitialize_steps,
         read_from_replicas=read_from_replicas,
+        dynamic_startup_nodes=dynamic_startup_nodes,
         address_remap=address_remap,
         startup_nodes=startup_nodes,
         cluster_error_retry_attempts=cluster_error_retry_attempts,
+        **cluster_kwargs,
     )

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -7,11 +7,27 @@ from redis.exceptions import RedisError
 from .._version import get_package_version
 from .cluster import Cluster_Conn, Is_Cluster
 from .graph import AsyncGraph
+from .sentinel import Is_Sentinel, Sentinel_Conn
 
 # config command
 UDF_CMD = "GRAPH.UDF"
 LIST_CMD = "GRAPH.LIST"
 CONFIG_CMD = "GRAPH.CONFIG"
+
+TOPOLOGY_MODES = {"auto", "standalone", "cluster", "sentinel"}
+FROM_URL_CLIENT_KWARGS = {
+    "topology_mode",
+    "sentinel_service_name",
+    "sentinel_nodes",
+    "cluster_error_retry_attempts",
+    "startup_nodes",
+    "require_full_coverage",
+    "reinitialize_steps",
+    "read_from_replicas",
+    "dynamic_startup_nodes",
+    "url",
+    "address_remap",
+}
 
 
 class FalkorDB:
@@ -69,8 +85,18 @@ class FalkorDB:
         require_full_coverage=False,
         reinitialize_steps=5,
         read_from_replicas=False,
+        dynamic_startup_nodes=True,
+        url=None,
         address_remap=None,
+        topology_mode="auto",
+        sentinel_service_name=None,
+        sentinel_nodes=None,
     ):
+        if topology_mode not in TOPOLOGY_MODES:
+            raise ValueError(
+                "Invalid topology_mode. Expected one of: "
+                "'auto', 'standalone', 'cluster', 'sentinel'."
+            )
 
         conn = redis.Redis(
             host=host,
@@ -105,8 +131,29 @@ class FalkorDB:
             credential_provider=credential_provider,
             protocol=protocol,
         )
+        resolved_topology_mode = topology_mode
+        self.sentinel = None
+        self.service_name = None
 
-        if Is_Cluster(conn):
+        should_use_sentinel = topology_mode == "sentinel"
+        if topology_mode == "auto":
+            should_use_sentinel = Is_Sentinel(conn)
+
+        if should_use_sentinel:
+            self.sentinel, self.service_name = Sentinel_Conn(
+                conn,
+                ssl,
+                service_name=sentinel_service_name,
+                sentinel_nodes=sentinel_nodes,
+            )
+            conn = self.sentinel.master_for(self.service_name, ssl=ssl)
+            resolved_topology_mode = "sentinel"
+
+        should_use_cluster = topology_mode == "cluster"
+        if topology_mode == "auto":
+            should_use_cluster = Is_Cluster(conn)
+
+        if should_use_cluster:
             conn = Cluster_Conn(
                 conn,
                 ssl,
@@ -115,10 +162,16 @@ class FalkorDB:
                 require_full_coverage,
                 reinitialize_steps,
                 read_from_replicas,
+                dynamic_startup_nodes,
+                url,
                 address_remap,
             )
+            resolved_topology_mode = "cluster"
+        elif resolved_topology_mode == "auto":
+            resolved_topology_mode = "standalone"
 
         self.connection = conn
+        self._topology_mode = resolved_topology_mode
         self.flushdb = conn.flushdb
         self.execute_command = conn.execute_command
 
@@ -147,11 +200,15 @@ class FalkorDB:
             url = "redis://" + url[len("falkor://") :]
         elif url.startswith("falkors://"):
             url = "rediss://" + url[len("falkors://") :]
+        client_kwargs = {
+            key: kwargs.pop(key)
+            for key in tuple(kwargs.keys())
+            if key in FROM_URL_CLIENT_KWARGS
+        }
 
         kwargs["decode_responses"] = True
         conn = redis.from_url(url, **kwargs)
-
-        return cls(connection_pool=conn.connection_pool)
+        return cls(connection_pool=conn.connection_pool, **client_kwargs)
 
     def select_graph(self, graph_id: str) -> AsyncGraph:
         """
@@ -235,6 +292,34 @@ class FalkorDB:
 
         await self.aclose()
 
+    def _is_cluster_topology(self) -> bool:
+        return self._topology_mode == "cluster"
+
+    def _cluster_primaries_target(self):
+        get_primaries = getattr(self.connection, "get_primaries", None)
+        if callable(get_primaries):
+            return list(get_primaries())
+        return getattr(self.connection, "PRIMARIES", "primaries")
+
+    def _normalize_cluster_fanout_response(self, response):
+        if not isinstance(response, dict):
+            return response
+        if len(response) == 0:
+            raise RedisError("No responses returned from cluster primaries")
+
+        first_value = next(iter(response.values()))
+        inconsistent = {
+            node: value
+            for node, value in response.items()
+            if isinstance(value, Exception) or value != first_value
+        }
+        if len(inconsistent) > 0:
+            raise RedisError(
+                f"Inconsistent responses from cluster primaries: {response}"
+            )
+
+        return first_value
+
     # GRAPH.UDF LOAD [REPLACE] <lib> <script>
     async def udf_load(self, name: str, script: str, replace: bool = False):
         """
@@ -254,11 +339,11 @@ class FalkorDB:
         args.extend([name, script])
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = await client.execute_command(*args)
+        if self._is_cluster_topology():
+            resp = await self.connection.execute_command(
+                *args, target_nodes=self._cluster_primaries_target()
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = await self.connection.execute_command(*args)
 
@@ -285,7 +370,11 @@ class FalkorDB:
 
         if with_code:
             args.append("WITHCODE")
-
+        if self._is_cluster_topology():
+            resp = await self.connection.execute_command(
+                *args, target_nodes=self._cluster_primaries_target()
+            )
+            return self._normalize_cluster_fanout_response(resp)
         return await self.connection.execute_command(*args)
 
     # GRAPH.UDF FLUSH
@@ -295,11 +384,13 @@ class FalkorDB:
         """
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = await client.execute_command(UDF_CMD, "FLUSH")
+        if self._is_cluster_topology():
+            resp = await self.connection.execute_command(
+                UDF_CMD,
+                "FLUSH",
+                target_nodes=self._cluster_primaries_target(),
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = await self.connection.execute_command(UDF_CMD, "FLUSH")
 
@@ -315,11 +406,14 @@ class FalkorDB:
         """
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = await client.execute_command(UDF_CMD, "DELETE", lib)
+        if self._is_cluster_topology():
+            resp = await self.connection.execute_command(
+                UDF_CMD,
+                "DELETE",
+                lib,
+                target_nodes=self._cluster_primaries_target(),
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = await self.connection.execute_command(UDF_CMD, "DELETE", lib)
 

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from falkordb.exceptions import SchemaVersionMismatchException
 from falkordb.execution_plan import ExecutionPlan
@@ -88,7 +88,7 @@ class AsyncGraph(Graph):
         except SchemaVersionMismatchException as e:
             # client view over the graph schema is out of sync
             # set client version and refresh local schema
-            self.schema.refresh(e.version)
+            await cast(GraphSchema, self.schema).refresh(e.version)
             raise e
 
     async def query(  # type: ignore[override]

--- a/falkordb/asyncio/sentinel.py
+++ b/falkordb/asyncio/sentinel.py
@@ -1,0 +1,98 @@
+from typing import cast
+
+import redis as sync_redis  # type: ignore[import-not-found]
+import redis.asyncio as redis  # type: ignore[import-not-found]
+from redis.asyncio.sentinel import Sentinel  # type: ignore[import-not-found]
+
+ASYNC_PROBE_KWARGS = {
+    "client_name",
+    "credential_provider",
+    "db",
+    "host",
+    "password",
+    "path",
+    "port",
+    "protocol",
+    "socket_connect_timeout",
+    "socket_keepalive",
+    "socket_keepalive_options",
+    "socket_timeout",
+    "ssl",
+    "ssl_ca_certs",
+    "ssl_ca_data",
+    "ssl_cert_reqs",
+    "ssl_check_hostname",
+    "ssl_certfile",
+    "ssl_keyfile",
+    "username",
+}
+
+
+def _is_ssl_connection(pool) -> bool:
+    try:
+        return issubclass(pool.connection_class, redis.SSLConnection)
+    except TypeError:
+        return pool.connection_class is redis.SSLConnection
+
+
+def _probe_kwargs(kwargs):
+    probe_kwargs = {
+        key: value for key, value in kwargs.items() if key in ASYNC_PROBE_KWARGS
+    }
+    probe_kwargs["decode_responses"] = True
+    return probe_kwargs
+
+
+# detect if a connection is a sentinel
+def Is_Sentinel(conn: redis.Redis):
+    pool = conn.connection_pool
+    kwargs = pool.connection_kwargs.copy()
+    kwargs["ssl"] = _is_ssl_connection(pool)
+
+    probe = sync_redis.Redis(**_probe_kwargs(kwargs))
+    try:
+        info = cast(dict, probe.info(section="server"))
+    finally:
+        probe.close()
+    return info.get("redis_mode") == "sentinel"
+
+
+# create a sentinel connection from a Redis connection
+def Sentinel_Conn(conn, ssl, service_name=None, sentinel_nodes=None):
+    connection_kwargs = conn.connection_pool.connection_kwargs.copy()
+
+    sentinels_conns = list(sentinel_nodes or [])
+    if len(sentinels_conns) == 0:
+        host = connection_kwargs.get("host")
+        port = connection_kwargs.get("port")
+        sentinels_conns.append((host, port))
+
+    if service_name is None:
+        pool = conn.connection_pool
+        probe_kwargs = connection_kwargs.copy()
+        probe_kwargs["ssl"] = _is_ssl_connection(pool)
+        probe = sync_redis.Redis(**_probe_kwargs(probe_kwargs))
+        try:
+            masters = cast(dict, probe.sentinel_masters())
+        finally:
+            probe.close()
+        if len(masters) != 1:
+            raise Exception("Multiple masters, require service name")
+        service_name = list(masters.keys())[0]
+
+    sentinel_kwargs = {}
+    if "username" in connection_kwargs:
+        sentinel_kwargs["username"] = connection_kwargs["username"]
+    if "password" in connection_kwargs:
+        sentinel_kwargs["password"] = connection_kwargs["password"]
+    if ssl:
+        sentinel_kwargs["ssl"] = True
+
+    connection_kwargs.pop("host", None)
+    connection_kwargs.pop("port", None)
+    connection_kwargs.pop("connection_pool", None)
+
+    return (
+        Sentinel(sentinels_conns, sentinel_kwargs=sentinel_kwargs, **connection_kwargs),
+        service_name,
+    )

--- a/falkordb/cluster.py
+++ b/falkordb/cluster.py
@@ -23,11 +23,11 @@ def Cluster_Conn(
     url=None,
     address_remap=None,
 ):
-    connection_kwargs = conn.connection_pool.connection_kwargs
-    host = connection_kwargs.pop("host")
-    port = connection_kwargs.pop("port")
-    username = connection_kwargs.pop("username")
-    password = connection_kwargs.pop("password")
+    connection_kwargs = conn.connection_pool.connection_kwargs.copy()
+    host = connection_kwargs.pop("host", None)
+    port = connection_kwargs.pop("port", None)
+    username = connection_kwargs.pop("username", None)
+    password = connection_kwargs.pop("password", None)
 
     retry = connection_kwargs.pop("retry", None)
     retry_on_timeout = connection_kwargs.pop("retry_on_timeout", None)
@@ -41,6 +41,9 @@ def Cluster_Conn(
             redis_exceptions.ConnectionError,
         ],
     )
+    connection_kwargs.pop("connection_pool", None)
+    connection_kwargs.pop("db", None)
+    connection_kwargs.pop("decode_responses", None)
     return RedisCluster(
         host=host,
         port=port,
@@ -59,4 +62,5 @@ def Cluster_Conn(
         address_remap=address_remap,
         startup_nodes=startup_nodes,
         cluster_error_retry_attempts=cluster_error_retry_attempts,
+        **connection_kwargs,
     )

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -309,7 +309,6 @@ class FalkorDB:
         if callable(get_primaries):
             return list(get_primaries())
         return getattr(self.connection, "PRIMARIES", "primaries")
-        return getattr(self.connection, "PRIMARIES", "primaries")
 
     def _normalize_cluster_fanout_response(self, response):
         if not isinstance(response, dict):

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -14,6 +14,21 @@ UDF_CMD = "GRAPH.UDF"
 LIST_CMD = "GRAPH.LIST"
 CONFIG_CMD = "GRAPH.CONFIG"
 
+TOPOLOGY_MODES = {"auto", "standalone", "cluster", "sentinel"}
+FROM_URL_CLIENT_KWARGS = {
+    "topology_mode",
+    "sentinel_service_name",
+    "sentinel_nodes",
+    "cluster_error_retry_attempts",
+    "startup_nodes",
+    "require_full_coverage",
+    "reinitialize_steps",
+    "read_from_replicas",
+    "dynamic_startup_nodes",
+    "url",
+    "address_remap",
+}
+
 
 class FalkorDB:
     """
@@ -78,7 +93,15 @@ class FalkorDB:
         dynamic_startup_nodes=True,
         url=None,
         address_remap=None,
+        topology_mode="auto",
+        sentinel_service_name=None,
+        sentinel_nodes=None,
     ):
+        if topology_mode not in TOPOLOGY_MODES:
+            raise ValueError(
+                "Invalid topology_mode. Expected one of: "
+                "'auto', 'standalone', 'cluster', 'sentinel'."
+            )
 
         conn = redis.Redis(
             host=host,
@@ -119,12 +142,29 @@ class FalkorDB:
             credential_provider=credential_provider,
             protocol=protocol,
         )
+        resolved_topology_mode = topology_mode
+        self.sentinel = None
+        self.service_name = None
 
-        if Is_Sentinel(conn):
-            self.sentinel, self.service_name = Sentinel_Conn(conn, ssl)
+        should_use_sentinel = topology_mode == "sentinel"
+        if topology_mode == "auto":
+            should_use_sentinel = Is_Sentinel(conn)
+
+        if should_use_sentinel:
+            self.sentinel, self.service_name = Sentinel_Conn(
+                conn,
+                ssl,
+                service_name=sentinel_service_name,
+                sentinel_nodes=sentinel_nodes,
+            )
             conn = self.sentinel.master_for(self.service_name, ssl=ssl)
+            resolved_topology_mode = "sentinel"
 
-        if Is_Cluster(conn):
+        should_use_cluster = topology_mode == "cluster"
+        if topology_mode == "auto":
+            should_use_cluster = Is_Cluster(conn)
+
+        if should_use_cluster:
             conn = Cluster_Conn(
                 conn,
                 ssl,
@@ -137,8 +177,12 @@ class FalkorDB:
                 url,
                 address_remap,
             )
+            resolved_topology_mode = "cluster"
+        elif resolved_topology_mode == "auto":
+            resolved_topology_mode = "standalone"
 
         self.connection = conn
+        self._topology_mode = resolved_topology_mode
         self.flushdb = conn.flushdb
         self.execute_command = conn.execute_command
 
@@ -167,11 +211,15 @@ class FalkorDB:
             url = "redis://" + url[len("falkor://") :]
         elif url.startswith("falkors://"):
             url = "rediss://" + url[len("falkors://") :]
+        client_kwargs = {
+            key: kwargs.pop(key)
+            for key in tuple(kwargs.keys())
+            if key in FROM_URL_CLIENT_KWARGS
+        }
 
         kwargs["decode_responses"] = True
         conn = redis.from_url(url, **kwargs)
-
-        return cls(connection_pool=conn.connection_pool)
+        return cls(connection_pool=conn.connection_pool, **client_kwargs)
 
     def select_graph(self, graph_id: str) -> Graph:
         """
@@ -253,6 +301,35 @@ class FalkorDB:
         """Close the connection when exiting a with-statement."""
         self.close()
 
+    def _is_cluster_topology(self) -> bool:
+        return self._topology_mode == "cluster"
+
+    def _cluster_primaries_target(self):
+        get_primaries = getattr(self.connection, "get_primaries", None)
+        if callable(get_primaries):
+            return list(get_primaries())
+        return getattr(self.connection, "PRIMARIES", "primaries")
+        return getattr(self.connection, "PRIMARIES", "primaries")
+
+    def _normalize_cluster_fanout_response(self, response):
+        if not isinstance(response, dict):
+            return response
+        if len(response) == 0:
+            raise RedisError("No responses returned from cluster primaries")
+
+        first_value = next(iter(response.values()))
+        inconsistent = {
+            node: value
+            for node, value in response.items()
+            if isinstance(value, Exception) or value != first_value
+        }
+        if len(inconsistent) > 0:
+            raise RedisError(
+                f"Inconsistent responses from cluster primaries: {response}"
+            )
+
+        return first_value
+
     # GRAPH.UDF LOAD [REPLACE] <lib> <script>
     def udf_load(self, name: str, script: str, replace: bool = False):
         """
@@ -272,11 +349,11 @@ class FalkorDB:
         args.extend([name, script])
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = client.execute_command(*args)
+        if self._is_cluster_topology():
+            resp = self.connection.execute_command(
+                *args, target_nodes=self._cluster_primaries_target()
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = self.connection.execute_command(*args)
 
@@ -303,7 +380,11 @@ class FalkorDB:
 
         if with_code:
             args.append("WITHCODE")
-
+        if self._is_cluster_topology():
+            resp = self.connection.execute_command(
+                *args, target_nodes=self._cluster_primaries_target()
+            )
+            return self._normalize_cluster_fanout_response(resp)
         return self.connection.execute_command(*args)
 
     # GRAPH.UDF FLUSH
@@ -313,11 +394,13 @@ class FalkorDB:
         """
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = client.execute_command(UDF_CMD, "FLUSH")
+        if self._is_cluster_topology():
+            resp = self.connection.execute_command(
+                UDF_CMD,
+                "FLUSH",
+                target_nodes=self._cluster_primaries_target(),
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = self.connection.execute_command(UDF_CMD, "FLUSH")
 
@@ -333,11 +416,14 @@ class FalkorDB:
         """
 
         # propagate command in cluster mode
-        if Is_Cluster(self.connection):
-            for node in self.connection.get_primaries():
-                # create a direct connection to this node
-                client = self.connection.get_redis_connection(node)
-                resp = client.execute_command(UDF_CMD, "DELETE", lib)
+        if self._is_cluster_topology():
+            resp = self.connection.execute_command(
+                UDF_CMD,
+                "DELETE",
+                lib,
+                target_nodes=self._cluster_primaries_target(),
+            )
+            return self._normalize_cluster_fanout_response(resp)
         else:
             resp = self.connection.execute_command(UDF_CMD, "DELETE", lib)
 

--- a/falkordb/sentinel.py
+++ b/falkordb/sentinel.py
@@ -8,24 +8,17 @@ def Is_Sentinel(conn):
 
 
 # create a sentinel connection from a Redis connection
-def Sentinel_Conn(conn, ssl):
-    # collect masters
-    masters = conn.sentinel_masters()
-
-    # abort if multiple masters are detected
-    if len(masters) != 1:
-        raise Exception("Multiple masters, require service name")
-
-    # monitored service name
-    service_name = list(masters.keys())[0]
+def Sentinel_Conn(conn, ssl, service_name=None, sentinel_nodes=None):
+    # use the same connection arguments e.g. username and password
+    connection_kwargs = conn.connection_pool.connection_kwargs.copy()
 
     # list of sentinels connection information
-    sentinels_conns = []
-
-    # current sentinel
-    host = conn.connection_pool.connection_kwargs["host"]
-    port = conn.connection_pool.connection_kwargs["port"]
-    sentinels_conns.append((host, port))
+    sentinels_conns = list(sentinel_nodes or [])
+    if len(sentinels_conns) == 0:
+        # current sentinel
+        host = connection_kwargs.get("host")
+        port = connection_kwargs.get("port")
+        sentinels_conns.append((host, port))
 
     # additional sentinels
     # sentinels = conn.sentinel_sentinels(service_name)
@@ -33,9 +26,14 @@ def Sentinel_Conn(conn, ssl):
     #    ip = sentinel['ip']
     #    port = sentinel['port']
     #    sentinels_conns.append((host, port))
-
-    # use the same connection arguments e.g. username and password
-    connection_kwargs = conn.connection_pool.connection_kwargs
+    if service_name is None:
+        # collect masters
+        masters = conn.sentinel_masters()
+        # abort if multiple masters are detected
+        if len(masters) != 1:
+            raise Exception("Multiple masters, require service name")
+        # monitored service name
+        service_name = list(masters.keys())[0]
 
     # construct sentinel arguments
     sentinel_kwargs = {}
@@ -45,6 +43,9 @@ def Sentinel_Conn(conn, ssl):
         sentinel_kwargs["password"] = connection_kwargs["password"]
     if ssl:
         sentinel_kwargs["ssl"] = True
+    connection_kwargs.pop("host", None)
+    connection_kwargs.pop("port", None)
+    connection_kwargs.pop("connection_pool", None)
 
     return (
         Sentinel(sentinels_conns, sentinel_kwargs=sentinel_kwargs, **connection_kwargs),

--- a/tests/test_cluster_management.py
+++ b/tests/test_cluster_management.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from redis.exceptions import RedisError
+
+import falkordb.asyncio.cluster as async_cluster_module
+import falkordb.falkordb as sync_falkordb_module
+from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+from falkordb.asyncio.graph import AsyncGraph
+from falkordb.exceptions import SchemaVersionMismatchException
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
+
+
+def test_sync_cluster_conn_does_not_mutate_connection_kwargs(monkeypatch):
+    original_kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "username": "user",
+        "password": "pass",
+        "socket_timeout": 1,
+    }
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs=original_kwargs.copy())
+    )
+
+    import falkordb.cluster as sync_cluster_module
+
+    monkeypatch.setattr(sync_cluster_module, "RedisCluster", lambda **kwargs: kwargs)
+    result = sync_cluster_module.Cluster_Conn(conn, ssl=False)
+
+    assert conn.connection_pool.connection_kwargs == original_kwargs
+    assert result["host"] == "localhost"
+    assert result["port"] == 6379
+
+
+def test_async_cluster_conn_does_not_mutate_connection_kwargs(monkeypatch):
+    original_kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "username": "user",
+        "password": "pass",
+        "socket_timeout": 1,
+        "unknown_option": "ignore_me",
+    }
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs=original_kwargs.copy())
+    )
+
+    monkeypatch.setattr(async_cluster_module, "RedisCluster", lambda **kwargs: kwargs)
+    result = async_cluster_module.Cluster_Conn(conn, ssl=False)
+
+    assert conn.connection_pool.connection_kwargs == original_kwargs
+    assert result["host"] == "localhost"
+    assert result["port"] == 6379
+    assert result["socket_timeout"] == 1
+    assert "unknown_option" not in result
+
+
+def test_sync_udf_cluster_fanout_targets_primaries():
+    db = object.__new__(SyncFalkorDB)
+    execute_command = Mock(return_value={"primary-1": "OK", "primary-2": "OK"})
+    db.connection = SimpleNamespace(
+        execute_command=execute_command,
+        PRIMARIES="primaries",
+    )
+    db._topology_mode = "cluster"
+
+    response = db.udf_flush()
+
+    assert response == "OK"
+    execute_command.assert_called_once_with(
+        "GRAPH.UDF",
+        "FLUSH",
+        target_nodes="primaries",
+    )
+
+
+def test_sync_udf_cluster_fanout_raises_on_inconsistent_responses():
+    db = object.__new__(SyncFalkorDB)
+    execute_command = Mock(return_value={"primary-1": "OK", "primary-2": "ERR"})
+    db.connection = SimpleNamespace(
+        execute_command=execute_command,
+        PRIMARIES="primaries",
+    )
+    db._topology_mode = "cluster"
+
+    with pytest.raises(RedisError):
+        db.udf_flush()
+
+
+@pytest.mark.asyncio
+async def test_async_udf_cluster_fanout_targets_primaries():
+    db = object.__new__(AsyncFalkorDB)
+    execute_command = AsyncMock(return_value={"primary-1": "OK", "primary-2": "OK"})
+    db.connection = SimpleNamespace(
+        execute_command=execute_command,
+        PRIMARIES="primaries",
+    )
+    db._topology_mode = "cluster"
+
+    response = await db.udf_delete("lib")
+
+    assert response == "OK"
+    execute_command.assert_awaited_once_with(
+        "GRAPH.UDF",
+        "DELETE",
+        "lib",
+        target_nodes="primaries",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_query_awaits_schema_refresh_on_version_mismatch():
+    client = SimpleNamespace(
+        execute_command=AsyncMock(side_effect=SchemaVersionMismatchException(7))
+    )
+    graph = AsyncGraph(client, "async_graph")
+    graph.schema = SimpleNamespace(refresh=AsyncMock())
+
+    with pytest.raises(SchemaVersionMismatchException):
+        await graph.query("RETURN 1")
+
+    graph.schema.refresh.assert_awaited_once_with(7)
+
+
+def test_topology_mode_standalone_skips_auto_probe(monkeypatch):
+    fake_conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs={}),
+        flushdb=Mock(),
+        execute_command=Mock(),
+        close=Mock(),
+    )
+    monkeypatch.setattr(sync_falkordb_module.redis, "Redis", lambda **kwargs: fake_conn)
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Sentinel",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe sentinel")),
+    )
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Cluster",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe cluster")),
+    )
+
+    db = SyncFalkorDB(topology_mode="standalone")
+
+    assert db._topology_mode == "standalone"

--- a/tests/test_cluster_management.py
+++ b/tests/test_cluster_management.py
@@ -1,15 +1,50 @@
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from redis.exceptions import RedisError
 
+if "redis.driver_info" not in sys.modules:
+    redis_driver_info = types.ModuleType("redis.driver_info")
+
+    class _DriverInfo:
+        def __init__(self, lib_name, lib_version):
+            self.lib_name = lib_name
+            self.lib_version = lib_version
+
+    redis_driver_info.DriverInfo = _DriverInfo
+    sys.modules["redis.driver_info"] = redis_driver_info
+
 import falkordb.asyncio.cluster as async_cluster_module
+import falkordb.asyncio.falkordb as async_falkordb_module
+import falkordb.asyncio.sentinel as async_sentinel_module
+import falkordb.cluster as sync_cluster_module
 import falkordb.falkordb as sync_falkordb_module
+import falkordb.sentinel as sync_sentinel_module
 from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
 from falkordb.asyncio.graph import AsyncGraph
 from falkordb.exceptions import SchemaVersionMismatchException
 from falkordb.falkordb import FalkorDB as SyncFalkorDB
+
+
+def _sync_conn(connection_kwargs=None):
+    return SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs=connection_kwargs or {}),
+        flushdb=Mock(),
+        execute_command=Mock(),
+        close=Mock(),
+    )
+
+
+def _async_conn(connection_kwargs=None):
+    return SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs=connection_kwargs or {}),
+        flushdb=AsyncMock(),
+        execute_command=AsyncMock(),
+        aclose=AsyncMock(),
+    )
 
 
 def test_sync_cluster_conn_does_not_mutate_connection_kwargs(monkeypatch):
@@ -23,8 +58,6 @@ def test_sync_cluster_conn_does_not_mutate_connection_kwargs(monkeypatch):
     conn = SimpleNamespace(
         connection_pool=SimpleNamespace(connection_kwargs=original_kwargs.copy())
     )
-
-    import falkordb.cluster as sync_cluster_module
 
     monkeypatch.setattr(sync_cluster_module, "RedisCluster", lambda **kwargs: kwargs)
     result = sync_cluster_module.Cluster_Conn(conn, ssl=False)
@@ -48,13 +81,270 @@ def test_async_cluster_conn_does_not_mutate_connection_kwargs(monkeypatch):
     )
 
     monkeypatch.setattr(async_cluster_module, "RedisCluster", lambda **kwargs: kwargs)
-    result = async_cluster_module.Cluster_Conn(conn, ssl=False)
+    result = async_cluster_module.Cluster_Conn(
+        conn, ssl=False, dynamic_startup_nodes=False, url="redis://cluster"
+    )
 
     assert conn.connection_pool.connection_kwargs == original_kwargs
     assert result["host"] == "localhost"
     assert result["port"] == 6379
     assert result["socket_timeout"] == 1
+    assert result["dynamic_startup_nodes"] is False
     assert "unknown_option" not in result
+
+
+def test_async_cluster_probe_kwargs_filters_supported_fields():
+    kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "password": "pw",
+        "ignored": "value",
+    }
+    filtered = async_cluster_module._probe_kwargs(kwargs)
+    assert filtered["host"] == "localhost"
+    assert filtered["port"] == 6379
+    assert filtered["password"] == "pw"
+    assert filtered["decode_responses"] is True
+    assert "ignored" not in filtered
+
+
+def test_async_sentinel_probe_kwargs_filters_supported_fields():
+    kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "password": "pw",
+        "ignored": "value",
+    }
+    filtered = async_sentinel_module._probe_kwargs(kwargs)
+    assert filtered["host"] == "localhost"
+    assert filtered["port"] == 6379
+    assert filtered["password"] == "pw"
+    assert filtered["decode_responses"] is True
+    assert "ignored" not in filtered
+
+
+def test_async_ssl_connection_helper_handles_non_type():
+    pool = SimpleNamespace(connection_class=object())
+    assert async_cluster_module._is_ssl_connection(pool) is False
+    assert async_sentinel_module._is_ssl_connection(pool) is False
+
+
+def test_async_is_cluster_uses_sync_probe_and_closes(monkeypatch):
+    probe = SimpleNamespace(
+        info=Mock(return_value={"redis_mode": "cluster"}),
+        close=Mock(),
+    )
+    probe_ctor = Mock(return_value=probe)
+    monkeypatch.setattr(async_cluster_module.sync_redis, "Redis", probe_ctor)
+
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 6379, "ignored": "x"},
+            connection_class=async_cluster_module.redis.SSLConnection,
+        )
+    )
+
+    assert async_cluster_module.Is_Cluster(conn) is True
+    probe.info.assert_called_once_with(section="server")
+    probe.close.assert_called_once()
+    probe_kwargs = probe_ctor.call_args.kwargs
+    assert probe_kwargs["host"] == "127.0.0.1"
+    assert probe_kwargs["port"] == 6379
+    assert probe_kwargs["ssl"] is True
+    assert probe_kwargs["decode_responses"] is True
+    assert "ignored" not in probe_kwargs
+
+
+def test_async_is_sentinel_uses_sync_probe_and_closes(monkeypatch):
+    probe = SimpleNamespace(
+        info=Mock(return_value={"redis_mode": "sentinel"}),
+        close=Mock(),
+    )
+    probe_ctor = Mock(return_value=probe)
+    monkeypatch.setattr(async_sentinel_module.sync_redis, "Redis", probe_ctor)
+
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 26379, "ignored": "x"},
+            connection_class=async_sentinel_module.redis.SSLConnection,
+        )
+    )
+
+    assert async_sentinel_module.Is_Sentinel(conn) is True
+    probe.info.assert_called_once_with(section="server")
+    probe.close.assert_called_once()
+    probe_kwargs = probe_ctor.call_args.kwargs
+    assert probe_kwargs["host"] == "127.0.0.1"
+    assert probe_kwargs["port"] == 26379
+    assert probe_kwargs["ssl"] is True
+    assert probe_kwargs["decode_responses"] is True
+    assert "ignored" not in probe_kwargs
+
+
+def test_sync_sentinel_conn_uses_supplied_service_and_nodes(monkeypatch):
+    conn_kwargs = {
+        "host": "127.0.0.1",
+        "port": 26379,
+        "username": "user",
+        "password": "pass",
+        "socket_timeout": 1,
+    }
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(connection_kwargs=conn_kwargs.copy())
+    )
+    sentinel_ctor = Mock(return_value="sentinel-conn")
+    monkeypatch.setattr(sync_sentinel_module, "Sentinel", sentinel_ctor)
+
+    sentinel, service_name = sync_sentinel_module.Sentinel_Conn(
+        conn,
+        ssl=True,
+        service_name="mymaster",
+        sentinel_nodes=[("s1", 26379)],
+    )
+
+    assert sentinel == "sentinel-conn"
+    assert service_name == "mymaster"
+    sentinel_ctor.assert_called_once()
+    assert sentinel_ctor.call_args.args[0] == [("s1", 26379)]
+    assert sentinel_ctor.call_args.kwargs["sentinel_kwargs"] == {
+        "username": "user",
+        "password": "pass",
+        "ssl": True,
+    }
+    assert sentinel_ctor.call_args.kwargs["socket_timeout"] == 1
+    assert conn.connection_pool.connection_kwargs == conn_kwargs
+
+
+def test_sync_sentinel_conn_discovers_single_master(monkeypatch):
+    conn = SimpleNamespace(
+        sentinel_masters=Mock(return_value={"mymaster": {}}),
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 26379}
+        ),
+    )
+    sentinel_ctor = Mock(return_value="sentinel-conn")
+    monkeypatch.setattr(sync_sentinel_module, "Sentinel", sentinel_ctor)
+
+    _, service_name = sync_sentinel_module.Sentinel_Conn(conn, ssl=False)
+    assert service_name == "mymaster"
+    conn.sentinel_masters.assert_called_once()
+    assert sentinel_ctor.call_args.args[0] == [("127.0.0.1", 26379)]
+
+
+def test_sync_sentinel_conn_raises_on_multiple_masters():
+    conn = SimpleNamespace(
+        sentinel_masters=Mock(return_value={"m1": {}, "m2": {}}),
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 26379}
+        ),
+    )
+    with pytest.raises(Exception, match="Multiple masters"):
+        sync_sentinel_module.Sentinel_Conn(conn, ssl=False)
+
+
+def test_async_sentinel_conn_uses_supplied_service_without_probe(monkeypatch):
+    conn_kwargs = {
+        "host": "127.0.0.1",
+        "port": 26379,
+        "username": "user",
+        "password": "pass",
+        "socket_timeout": 1,
+    }
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs=conn_kwargs.copy(),
+            connection_class=object(),
+        )
+    )
+    sentinel_ctor = Mock(return_value="async-sentinel-conn")
+    monkeypatch.setattr(async_sentinel_module, "Sentinel", sentinel_ctor)
+    monkeypatch.setattr(
+        async_sentinel_module.sync_redis,
+        "Redis",
+        Mock(side_effect=AssertionError("should not probe")),
+    )
+
+    sentinel, service_name = async_sentinel_module.Sentinel_Conn(
+        conn,
+        ssl=True,
+        service_name="mymaster",
+        sentinel_nodes=[("s1", 26379)],
+    )
+
+    assert sentinel == "async-sentinel-conn"
+    assert service_name == "mymaster"
+    sentinel_ctor.assert_called_once()
+    assert sentinel_ctor.call_args.args[0] == [("s1", 26379)]
+    assert sentinel_ctor.call_args.kwargs["sentinel_kwargs"] == {
+        "username": "user",
+        "password": "pass",
+        "ssl": True,
+    }
+    assert sentinel_ctor.call_args.kwargs["socket_timeout"] == 1
+    assert conn.connection_pool.connection_kwargs == conn_kwargs
+
+
+def test_async_sentinel_conn_discovers_single_master(monkeypatch):
+    probe = SimpleNamespace(
+        sentinel_masters=Mock(return_value={"mymaster": {}}),
+        close=Mock(),
+    )
+    probe_ctor = Mock(return_value=probe)
+    monkeypatch.setattr(async_sentinel_module.sync_redis, "Redis", probe_ctor)
+    sentinel_ctor = Mock(return_value="async-sentinel-conn")
+    monkeypatch.setattr(async_sentinel_module, "Sentinel", sentinel_ctor)
+
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 26379},
+            connection_class=async_sentinel_module.redis.SSLConnection,
+        )
+    )
+
+    _, service_name = async_sentinel_module.Sentinel_Conn(conn, ssl=False)
+    assert service_name == "mymaster"
+    probe.sentinel_masters.assert_called_once()
+    probe.close.assert_called_once()
+    assert sentinel_ctor.call_args.args[0] == [("127.0.0.1", 26379)]
+    probe_kwargs = probe_ctor.call_args.kwargs
+    assert probe_kwargs["host"] == "127.0.0.1"
+    assert probe_kwargs["port"] == 26379
+    assert probe_kwargs["ssl"] is True
+    assert probe_kwargs["decode_responses"] is True
+
+
+def test_async_sentinel_conn_raises_on_multiple_masters(monkeypatch):
+    probe = SimpleNamespace(
+        sentinel_masters=Mock(return_value={"m1": {}, "m2": {}}),
+        close=Mock(),
+    )
+    monkeypatch.setattr(
+        async_sentinel_module.sync_redis, "Redis", Mock(return_value=probe)
+    )
+    conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={"host": "127.0.0.1", "port": 26379},
+            connection_class=async_sentinel_module.redis.SSLConnection,
+        )
+    )
+    with pytest.raises(Exception, match="Multiple masters"):
+        async_sentinel_module.Sentinel_Conn(conn, ssl=False)
+    probe.close.assert_called_once()
+
+
+def test_sync_cluster_primaries_target_prefers_get_primaries():
+    db = object.__new__(SyncFalkorDB)
+    db.connection = SimpleNamespace(get_primaries=lambda: ("p1", "p2"), PRIMARIES="all")
+    assert db._cluster_primaries_target() == ["p1", "p2"]
+
+
+def test_sync_normalize_cluster_fanout_response_handles_edges():
+    db = object.__new__(SyncFalkorDB)
+    assert db._normalize_cluster_fanout_response("OK") == "OK"
+    with pytest.raises(RedisError, match="No responses"):
+        db._normalize_cluster_fanout_response({})
+    with pytest.raises(RedisError, match="Inconsistent responses"):
+        db._normalize_cluster_fanout_response({"n1": "OK", "n2": RedisError("boom")})
 
 
 def test_sync_udf_cluster_fanout_targets_primaries():
@@ -89,6 +379,54 @@ def test_sync_udf_cluster_fanout_raises_on_inconsistent_responses():
         db.udf_flush()
 
 
+def test_sync_udf_cluster_load_and_list_use_node_targets():
+    db = object.__new__(SyncFalkorDB)
+    execute_command = Mock(return_value={"p1": "OK", "p2": "OK"})
+    db.connection = SimpleNamespace(
+        execute_command=execute_command,
+        get_primaries=lambda: ("p1", "p2"),
+    )
+    db._topology_mode = "cluster"
+
+    load_result = db.udf_load("lib", "code", replace=True)
+    list_result = db.udf_list("lib", with_code=True)
+
+    assert load_result == "OK"
+    assert list_result == "OK"
+    execute_command.assert_any_call(
+        "GRAPH.UDF",
+        "LOAD",
+        "REPLACE",
+        "lib",
+        "code",
+        target_nodes=["p1", "p2"],
+    )
+    execute_command.assert_any_call(
+        "GRAPH.UDF",
+        "LIST",
+        "lib",
+        "WITHCODE",
+        target_nodes=["p1", "p2"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_cluster_primaries_target_prefers_get_primaries():
+    db = object.__new__(AsyncFalkorDB)
+    db.connection = SimpleNamespace(get_primaries=lambda: ("p1", "p2"), PRIMARIES="all")
+    assert db._cluster_primaries_target() == ["p1", "p2"]
+
+
+@pytest.mark.asyncio
+async def test_async_normalize_cluster_fanout_response_handles_edges():
+    db = object.__new__(AsyncFalkorDB)
+    assert db._normalize_cluster_fanout_response("OK") == "OK"
+    with pytest.raises(RedisError, match="No responses"):
+        db._normalize_cluster_fanout_response({})
+    with pytest.raises(RedisError, match="Inconsistent responses"):
+        db._normalize_cluster_fanout_response({"n1": "OK", "n2": RedisError("boom")})
+
+
 @pytest.mark.asyncio
 async def test_async_udf_cluster_fanout_targets_primaries():
     db = object.__new__(AsyncFalkorDB)
@@ -111,6 +449,38 @@ async def test_async_udf_cluster_fanout_targets_primaries():
 
 
 @pytest.mark.asyncio
+async def test_async_udf_cluster_load_and_list_use_node_targets():
+    db = object.__new__(AsyncFalkorDB)
+    execute_command = AsyncMock(return_value={"p1": "OK", "p2": "OK"})
+    db.connection = SimpleNamespace(
+        execute_command=execute_command,
+        get_primaries=lambda: ("p1", "p2"),
+    )
+    db._topology_mode = "cluster"
+
+    load_result = await db.udf_load("lib", "code", replace=True)
+    list_result = await db.udf_list("lib", with_code=True)
+
+    assert load_result == "OK"
+    assert list_result == "OK"
+    execute_command.assert_any_await(
+        "GRAPH.UDF",
+        "LOAD",
+        "REPLACE",
+        "lib",
+        "code",
+        target_nodes=["p1", "p2"],
+    )
+    execute_command.assert_any_await(
+        "GRAPH.UDF",
+        "LIST",
+        "lib",
+        "WITHCODE",
+        target_nodes=["p1", "p2"],
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_query_awaits_schema_refresh_on_version_mismatch():
     client = SimpleNamespace(
         execute_command=AsyncMock(side_effect=SchemaVersionMismatchException(7))
@@ -124,13 +494,19 @@ async def test_async_query_awaits_schema_refresh_on_version_mismatch():
     graph.schema.refresh.assert_awaited_once_with(7)
 
 
+def test_sync_topology_mode_invalid_raises():
+    with pytest.raises(ValueError, match="Invalid topology_mode"):
+        SyncFalkorDB(topology_mode="invalid")
+
+
+@pytest.mark.asyncio
+async def test_async_topology_mode_invalid_raises():
+    with pytest.raises(ValueError, match="Invalid topology_mode"):
+        AsyncFalkorDB(topology_mode="invalid")
+
+
 def test_topology_mode_standalone_skips_auto_probe(monkeypatch):
-    fake_conn = SimpleNamespace(
-        connection_pool=SimpleNamespace(connection_kwargs={}),
-        flushdb=Mock(),
-        execute_command=Mock(),
-        close=Mock(),
-    )
+    fake_conn = _sync_conn({})
     monkeypatch.setattr(sync_falkordb_module.redis, "Redis", lambda **kwargs: fake_conn)
     monkeypatch.setattr(
         sync_falkordb_module,
@@ -144,5 +520,195 @@ def test_topology_mode_standalone_skips_auto_probe(monkeypatch):
     )
 
     db = SyncFalkorDB(topology_mode="standalone")
-
     assert db._topology_mode == "standalone"
+
+
+def test_sync_auto_topology_resolves_standalone(monkeypatch):
+    fake_conn = _sync_conn({})
+    monkeypatch.setattr(sync_falkordb_module.redis, "Redis", lambda **kwargs: fake_conn)
+    monkeypatch.setattr(sync_falkordb_module, "Is_Sentinel", lambda conn: False)
+    monkeypatch.setattr(sync_falkordb_module, "Is_Cluster", lambda conn: False)
+
+    db = SyncFalkorDB(topology_mode="auto")
+    assert db._topology_mode == "standalone"
+
+
+def test_sync_explicit_cluster_skips_auto_probes(monkeypatch):
+    base_conn = _sync_conn({"host": "localhost", "port": 6379})
+    cluster_conn = _sync_conn({"host": "localhost", "port": 6379})
+    cluster_conn_builder = Mock(return_value=cluster_conn)
+
+    monkeypatch.setattr(sync_falkordb_module.redis, "Redis", lambda **kwargs: base_conn)
+    monkeypatch.setattr(sync_falkordb_module, "Cluster_Conn", cluster_conn_builder)
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Sentinel",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe sentinel")),
+    )
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Cluster",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe cluster")),
+    )
+
+    db = SyncFalkorDB(topology_mode="cluster")
+    assert db._topology_mode == "cluster"
+    assert db.connection is cluster_conn
+    cluster_conn_builder.assert_called_once()
+
+
+def test_sync_explicit_sentinel_skips_cluster_probe(monkeypatch):
+    base_conn = _sync_conn({"host": "localhost", "port": 26379})
+    master_conn = _sync_conn({"host": "localhost", "port": 6379})
+    sentinel_obj = SimpleNamespace(master_for=Mock(return_value=master_conn))
+    sentinel_conn_builder = Mock(return_value=(sentinel_obj, "mymaster"))
+
+    monkeypatch.setattr(sync_falkordb_module.redis, "Redis", lambda **kwargs: base_conn)
+    monkeypatch.setattr(sync_falkordb_module, "Sentinel_Conn", sentinel_conn_builder)
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Sentinel",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe sentinel")),
+    )
+    monkeypatch.setattr(
+        sync_falkordb_module,
+        "Is_Cluster",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe cluster")),
+    )
+
+    db = SyncFalkorDB(
+        topology_mode="sentinel",
+        sentinel_service_name="mymaster",
+        sentinel_nodes=[("localhost", 26379)],
+    )
+    assert db._topology_mode == "sentinel"
+    assert db.connection is master_conn
+    sentinel_conn_builder.assert_called_once()
+    sentinel_obj.master_for.assert_called_once_with("mymaster", ssl=False)
+
+
+@pytest.mark.asyncio
+async def test_async_auto_topology_resolves_standalone(monkeypatch):
+    fake_conn = _async_conn({})
+    monkeypatch.setattr(
+        async_falkordb_module.redis, "Redis", lambda **kwargs: fake_conn
+    )
+    monkeypatch.setattr(async_falkordb_module, "Is_Sentinel", lambda conn: False)
+    monkeypatch.setattr(async_falkordb_module, "Is_Cluster", lambda conn: False)
+
+    db = AsyncFalkorDB(topology_mode="auto")
+    assert db._topology_mode == "standalone"
+
+
+@pytest.mark.asyncio
+async def test_async_explicit_cluster_skips_auto_probes(monkeypatch):
+    base_conn = _async_conn({"host": "localhost", "port": 6379})
+    cluster_conn = _async_conn({"host": "localhost", "port": 6379})
+    cluster_conn_builder = Mock(return_value=cluster_conn)
+
+    monkeypatch.setattr(
+        async_falkordb_module.redis, "Redis", lambda **kwargs: base_conn
+    )
+    monkeypatch.setattr(async_falkordb_module, "Cluster_Conn", cluster_conn_builder)
+    monkeypatch.setattr(
+        async_falkordb_module,
+        "Is_Sentinel",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe sentinel")),
+    )
+    monkeypatch.setattr(
+        async_falkordb_module,
+        "Is_Cluster",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe cluster")),
+    )
+
+    db = AsyncFalkorDB(topology_mode="cluster")
+    assert db._topology_mode == "cluster"
+    assert db.connection is cluster_conn
+    cluster_conn_builder.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_explicit_sentinel_skips_cluster_probe(monkeypatch):
+    base_conn = _async_conn({"host": "localhost", "port": 26379})
+    master_conn = _async_conn({"host": "localhost", "port": 6379})
+    sentinel_obj = SimpleNamespace(master_for=Mock(return_value=master_conn))
+    sentinel_conn_builder = Mock(return_value=(sentinel_obj, "mymaster"))
+
+    monkeypatch.setattr(
+        async_falkordb_module.redis, "Redis", lambda **kwargs: base_conn
+    )
+    monkeypatch.setattr(async_falkordb_module, "Sentinel_Conn", sentinel_conn_builder)
+    monkeypatch.setattr(
+        async_falkordb_module,
+        "Is_Sentinel",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe sentinel")),
+    )
+    monkeypatch.setattr(
+        async_falkordb_module,
+        "Is_Cluster",
+        lambda conn: (_ for _ in ()).throw(AssertionError("should not probe cluster")),
+    )
+
+    db = AsyncFalkorDB(
+        topology_mode="sentinel",
+        sentinel_service_name="mymaster",
+        sentinel_nodes=[("localhost", 26379)],
+    )
+    assert db._topology_mode == "sentinel"
+    assert db.connection is master_conn
+    sentinel_conn_builder.assert_called_once()
+    sentinel_obj.master_for.assert_called_once_with("mymaster", ssl=False)
+
+
+def test_sync_from_url_forwards_client_kwargs(monkeypatch):
+    redis_conn = SimpleNamespace(connection_pool="POOL")
+    from_url = Mock(return_value=redis_conn)
+    monkeypatch.setattr(sync_falkordb_module.redis, "from_url", from_url)
+    captured = {}
+
+    class DummySyncFalkorDB(SyncFalkorDB):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    DummySyncFalkorDB.from_url(
+        "falkor://localhost:6379",
+        topology_mode="cluster",
+        dynamic_startup_nodes=False,
+        socket_timeout=5,
+    )
+
+    from_url.assert_called_once_with(
+        "redis://localhost:6379",
+        socket_timeout=5,
+        decode_responses=True,
+    )
+    assert captured["connection_pool"] == "POOL"
+    assert captured["topology_mode"] == "cluster"
+    assert captured["dynamic_startup_nodes"] is False
+
+
+def test_async_from_url_forwards_client_kwargs(monkeypatch):
+    redis_conn = SimpleNamespace(connection_pool="POOL")
+    from_url = Mock(return_value=redis_conn)
+    monkeypatch.setattr(async_falkordb_module.redis, "from_url", from_url)
+    captured = {}
+
+    class DummyAsyncFalkorDB(AsyncFalkorDB):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    DummyAsyncFalkorDB.from_url(
+        "falkor://localhost:6379",
+        topology_mode="cluster",
+        dynamic_startup_nodes=False,
+        socket_timeout=5,
+    )
+
+    from_url.assert_called_once_with(
+        "redis://localhost:6379",
+        socket_timeout=5,
+        decode_responses=True,
+    )
+    assert captured["connection_pool"] == "POOL"
+    assert captured["topology_mode"] == "cluster"
+    assert captured["dynamic_startup_nodes"] is False


### PR DESCRIPTION
## Summary
- harden cluster connection builders to avoid mutating shared kwargs
- add explicit topology mode handling and routing consistency in sync/async clients
- add async sentinel support and align sentinel handling across sync/async
- fix async schema refresh path to properly await refresh on schema mismatch
- fix cluster UDF routing, including `GRAPH.UDF LIST`, to target primaries safely
- add regression tests for cluster management behavior and update docs

## Validation
- `python3 -m ruff format --check falkordb/cluster.py falkordb/sentinel.py falkordb/falkordb.py falkordb/asyncio/cluster.py falkordb/asyncio/sentinel.py falkordb/asyncio/falkordb.py falkordb/asyncio/graph.py tests/test_cluster_management.py`
- `python3 -m ruff check falkordb/cluster.py falkordb/sentinel.py falkordb/falkordb.py falkordb/asyncio/cluster.py falkordb/asyncio/sentinel.py falkordb/asyncio/falkordb.py falkordb/asyncio/graph.py tests/test_cluster_management.py`
- `python3 -m mypy falkordb/`
- fallback integration against FalkorDB 4.16.5 docker cluster: sync+async query paths and full UDF lifecycle passed
- note: local `python3 -m pytest tests/test_cluster_management.py` collection is blocked in this environment by `ModuleNotFoundError: redis.driver_info`

Co-Authored-By: Oz <oz-agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit topology mode selection (auto, standalone, cluster, sentinel) for deterministic connection behavior in high-availability and test environments.
  * Added asyncio Redis Sentinel support for high-availability configurations.

* **Documentation**
  * Updated with topology mode selection guide and configuration examples for standalone, cluster, and sentinel setups.

* **Tests**
  * Added cluster management and async schema refresh tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->