### PR TITLE
fix: escape newlines, carriage returns, and tabs in quote_string

### DIFF
--- a/falkordb/helpers.py
+++ b/falkordb/helpers.py
@@ -14,6 +14,9 @@ def quote_string(v):
 
     v = v.replace("\\", "\\\\")
     v = v.replace('"', '\\"')
+    v = v.replace("\n", "\\n")
+    v = v.replace("\r", "\\r")
+    v = v.replace("\t", "\\t")
 
     return f'"{v}"'
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,64 @@
+"""Tests for helpers.quote_string and stringify_param_value."""
+
+from falkordb.helpers import quote_string, stringify_param_value
+
+
+class TestQuoteString:
+    def test_simple_string(self):
+        assert quote_string("hello") == '"hello"'
+
+    def test_empty_string(self):
+        assert quote_string("") == '""'
+
+    def test_escapes_backslash(self):
+        assert quote_string("a\\b") == '"a\\\\b"'
+
+    def test_escapes_double_quote(self):
+        assert quote_string('a"b') == '"a\\"b"'
+
+    def test_escapes_newline(self):
+        result = quote_string("line1\nline2")
+        assert "\n" not in result
+        assert result == '"line1\\nline2"'
+
+    def test_escapes_carriage_return(self):
+        result = quote_string("line1\rline2")
+        assert "\r" not in result
+        assert result == '"line1\\rline2"'
+
+    def test_escapes_tab(self):
+        result = quote_string("col1\tcol2")
+        assert "\t" not in result
+        assert result == '"col1\\tcol2"'
+
+    def test_non_string_passthrough(self):
+        assert quote_string(42) == 42
+        assert quote_string(3.14) == 3.14
+
+    def test_bytes_decoded(self):
+        assert quote_string(b"hello") == '"hello"'
+
+    def test_combined_escapes(self):
+        result = quote_string('a"b\nc\\d')
+        assert result == '"a\\"b\\nc\\\\d"'
+
+
+class TestStringifyParamValue:
+    def test_string(self):
+        assert stringify_param_value("hello") == '"hello"'
+
+    def test_none(self):
+        assert stringify_param_value(None) == "null"
+
+    def test_list(self):
+        assert stringify_param_value([1, 2]) == "[1,2]"
+
+    def test_dict(self):
+        result = stringify_param_value({"key": "val"})
+        assert result == '{key:"val"}'
+
+    def test_nested_dict_with_newlines(self):
+        """Newlines in dict values must be escaped for CYPHER params header."""
+        result = stringify_param_value({"summary": "line1\nline2"})
+        assert "\n" not in result
+        assert "\\n" in result


### PR DESCRIPTION
## Summary

- `quote_string()` now escapes `\n`, `\r`, and `\t` in addition to `\\` and `"`
- Added `tests/test_helpers.py` with 15 tests covering `quote_string` and `stringify_param_value`

## Problem

`quote_string()` in `helpers.py` escapes backslashes and double quotes but not control characters. When strings containing newlines are serialized into the `CYPHER` params header by `_build_params_header()`, the header breaks across lines, causing FalkorDB to parse it as an incomplete command:

```
ResponseError: errMsg: Invalid input at end of input: expected '='
line: 1, column: 13, offset: 12
errCtx: CYPHER nodes
```

Any application storing multi-line text (summaries, descriptions, narratives) in graph properties hits this when using parameterized bulk queries.

## Fix

Three lines added to `quote_string()`:

```python
v = v.replace("\n", "\\n")
v = v.replace("\r", "\\r")
v = v.replace("\t", "\\t")
```

## Test plan

- [x] 15 new unit tests in `tests/test_helpers.py` covering all escape sequences
- [x] Verified with real-world multi-line node summaries from a knowledge graph ingestion pipeline

Fixes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of control characters in strings: newlines, carriage returns, and tabs are now properly escaped during serialization, ensuring data integrity and correct processing.

* **Tests**
  * Comprehensive test coverage added for string escaping and parameter serialization, validating behavior across multiple input types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->