### PR TITLE
fix: escape control characters in quote_string (fixes #201)

### DIFF
--- a/falkordb/helpers.py
+++ b/falkordb/helpers.py
@@ -14,6 +14,9 @@ def quote_string(v):
 
     v = v.replace("\\", "\\\\")
     v = v.replace('"', '\\"')
+    v = v.replace("\n", "\\n")
+    v = v.replace("\r", "\\r")
+    v = v.replace("\t", "\\t")
 
     return f'"{v}"'
 

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -210,6 +210,52 @@ async def test_param_invalid_keys_rejected():
 
 
 @pytest.mark.asyncio
+async def test_param_control_characters():
+    """Regression test for issue #201 — async mirror.
+
+    The params header must stay on one line, and escaping must be reversible
+    (a literal backslash-n stays a backslash-n).
+    """
+    pool = BlockingConnectionPool(
+        max_connections=16, timeout=None, decode_responses=True
+    )
+    db = FalkorDB(connection_pool=pool)
+    graph = db.select_graph("async_graph")
+    await graph.query("MATCH (d:AsyncDoc) DELETE d")
+
+    values = [
+        "line1\nline2",
+        "line1\r\nline2",
+        "col1\tcol2",
+        "trailing\n",
+        "\n",
+        'mixed "quote"\n\tand \\backslash\r\n',
+        "a\\nb",
+        "a\\tb",
+    ]
+    for value in values:
+        header = graph._build_params_header({"param": value})
+        assert "\n" not in header, f"raw newline in header for {value!r}"
+        assert "\r" not in header, f"raw carriage return in header for {value!r}"
+        assert "\t" not in header, f"raw tab in header for {value!r}"
+        result = await graph.query("RETURN $param", {"param": value})
+        assert [[value]] == result.result_set, f"failed for {value!r}"
+
+    nested = {"docs": [{"title": "a\tb", "body": "line1\nline2"}, {"body": "\r\n"}]}
+    header = graph._build_params_header({"nested": nested})
+    assert "\n" not in header and "\r" not in header and "\t" not in header
+    result = await graph.query("RETURN $nested", {"nested": nested})
+    assert [[nested]] == result.result_set
+
+    body = "line1\nline2\tend\r\n"
+    await graph.query("CREATE (:AsyncDoc {body: $body})", {"body": body})
+    result = await graph.query("MATCH (d:AsyncDoc) RETURN d.body")
+    assert [[body]] == result.result_set
+
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
 async def test_map():
     pool = BlockingConnectionPool(
         max_connections=16, timeout=None, decode_responses=True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -179,6 +179,48 @@ def test_param_invalid_keys_rejected(client):
         graph.query("RETURN $p", {"p": {"back`tick": 1}})
 
 
+def test_param_control_characters(client):
+    """Regression test for issue #201.
+
+    The CYPHER params header is a single line, so a newline, carriage return
+    or tab in a parameter value must be escaped rather than written verbatim.
+    Escaping must also be reversible: a value holding a literal backslash-n
+    has to stay a backslash-n and not come back as a newline.
+    """
+    graph = client
+
+    values = [
+        "line1\nline2",
+        "line1\r\nline2",
+        "col1\tcol2",
+        "trailing\n",
+        "\n",
+        'mixed "quote"\n\tand \\backslash\r\n',
+        "a\\nb",
+        "a\\tb",
+    ]
+    for value in values:
+        header = graph._build_params_header({"param": value})
+        assert "\n" not in header, f"raw newline in header for {value!r}"
+        assert "\r" not in header, f"raw carriage return in header for {value!r}"
+        assert "\t" not in header, f"raw tab in header for {value!r}"
+        result = graph.query("RETURN $param", {"param": value})
+        assert [[value]] == result.result_set, f"failed for {value!r}"
+
+    # Nested maps and lists must be escaped at every level.
+    nested = {"docs": [{"title": "a\tb", "body": "line1\nline2"}, {"body": "\r\n"}]}
+    header = graph._build_params_header({"nested": nested})
+    assert "\n" not in header and "\r" not in header and "\t" not in header
+    result = graph.query("RETURN $nested", {"nested": nested})
+    assert [[nested]] == result.result_set
+
+    # Multiline text stored as a node property and read back.
+    body = "line1\nline2\tend\r\n"
+    graph.query("CREATE (:Doc {body: $body})", {"body": body})
+    result = graph.query("MATCH (d:Doc) RETURN d.body")
+    assert [[body]] == result.result_set
+
+
 def test_map(client):
     g = client
 


### PR DESCRIPTION
`quote_string()` only escaped backslashes and double quotes, but
did not escape control characters like newline (`\n`), carriage
return (`\r`), and tab (`\t`). This caused the CYPHER params
header to break across multiple lines when a parameter value
contained newlines, resulting in an incomplete command being sent
to FalkorDB.

The fix adds escaping for `\n`, `\r`, and `\t` to `quote_string()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string handling to properly escape control characters (newlines, carriage returns, tabs) in database queries, ensuring strings with special formatting are stored and returned correctly.
* **Tests**
  * Added regression coverage to verify control characters are not emitted unescaped in generated query parameters and that values round-trip correctly for both simple and nested inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->