### PR TITLE
fix(client): accurate error message for empty graph_id in select_graph

### DIFF
--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -172,10 +172,12 @@ class FalkorDB:
         Returns:
             AsyncGraph: A new Graph instance associated with the selected graph.
         """
-        if not isinstance(graph_id, str) or graph_id == "":
+        if not isinstance(graph_id, str):
             raise TypeError(
                 f"Expected a string parameter, but received {type(graph_id)}."
             )
+        if graph_id == "":
+            raise TypeError("graph_id must be a non-empty string.")
 
         return AsyncGraph(self, graph_id)
 

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -192,10 +192,12 @@ class FalkorDB:
         Returns:
             Graph: A new Graph instance associated with the selected graph.
         """
-        if not isinstance(graph_id, str) or graph_id == "":
+        if not isinstance(graph_id, str):
             raise TypeError(
                 f"Expected a string parameter, but received {type(graph_id)}."
             )
+        if graph_id == "":
+            raise TypeError("graph_id must be a non-empty string.")
 
         return Graph(self, graph_id)
 

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -73,6 +73,19 @@ async def test_config(async_client):
 
 
 @pytest.mark.asyncio
+async def test_select_graph_invalid_id(async_client):
+    db = async_client
+
+    # graph_id must be a string
+    with pytest.raises(TypeError, match="Expected a string parameter"):
+        db.select_graph(None)
+
+    # graph_id must be a non-empty string
+    with pytest.raises(TypeError, match="non-empty string"):
+        db.select_graph("")
+
+
+@pytest.mark.asyncio
 async def test_connect_via_url(async_client):
     db = async_client
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -65,6 +65,18 @@ def test_config(client):
         db.config_set(config_name, "invalid value")
 
 
+def test_select_graph_invalid_id(client):
+    db = client
+
+    # graph_id must be a string
+    with pytest.raises(TypeError, match="Expected a string parameter"):
+        db.select_graph(None)
+
+    # graph_id must be a non-empty string
+    with pytest.raises(TypeError, match="non-empty string"):
+        db.select_graph("")
+
+
 def test_connect_via_url():
     # make sure we're able to connect via url
 


### PR DESCRIPTION
# Summary

`select_graph` validated `graph_id` with a single combined check (`not isinstance(graph_id, str) or graph_id == ""`), so passing an empty string produced a misleading error that claims a string was expected while a string was in fact received. This PR splits the check into two distinct, accurate messages while **preserving the existing exception contract**: both cases keep raising `TypeError` (per review feedback), only the empty-string message is corrected. Applied to both `FalkorDB` and `AsyncFalkorDB` for sync/async parity.

Fixes #244

## Reproduction

```python
from falkordb import FalkorDB

db = FalkorDB(host="localhost", port=6379)
db.select_graph("")
```

Before:

```
TypeError: Expected a string parameter, but received <class 'str'>.
```

After:

```
TypeError: graph_id must be a non-empty string.
```

Non-string input is unchanged:

```
>>> db.select_graph(None)
TypeError: Expected a string parameter, but received <class 'NoneType'>.
```

## Compatibility

No breaking change: the exception type stays `TypeError` for both invalid inputs; only the message for the empty-string case is corrected. (An earlier revision of this PR raised `ValueError` for the empty string; reverted per review to preserve the public exception contract.)

## Test coverage

- `tests/test_db.py::test_select_graph_invalid_id` — `TypeError` with the type message on `None`, `TypeError` with the non-empty message on `""` (asserted via `match=`)
- `tests/test_async_db.py::test_select_graph_invalid_id` — 1:1 async mirror on the `async_client` fixture

Rebased onto current `main`. Ran `ruff format --check .`, `ruff check .` and `mypy falkordb/` — all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `select_graph` argument validation by clearly distinguishing between invalid graph identifiers (non-string vs empty).
  * Invalid inputs now raise more specific exceptions, making error handling more predictable in both synchronous and asynchronous usage.
* **Tests**
  * Added coverage to verify the updated `select_graph` validation behavior for invalid graph identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->