### PR TITLE
docs: fix missing modules and dependency in Sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *.egg-info/
 coverage.xml
 wordlist.dic
+docs/_build/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 redis
+python-dateutil>=2.9.0
 sphinx_rtd_theme==3.1.0
 requests>=2.33.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/docs/source/falkordb.asyncio.rst
+++ b/docs/source/falkordb.asyncio.rst
@@ -4,6 +4,14 @@ falkordb.asyncio package
 Submodules
 ----------
 
+falkordb.asyncio.cluster module
+--------------------------------
+
+.. automodule:: falkordb.asyncio.cluster
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 falkordb.asyncio.falkordb module
 --------------------------------
 

--- a/docs/source/falkordb.rst
+++ b/docs/source/falkordb.rst
@@ -12,6 +12,14 @@ Subpackages
 Submodules
 ----------
 
+falkordb.cluster module
+------------------------
+
+.. automodule:: falkordb.cluster
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 falkordb.edge module
 --------------------
 
@@ -88,6 +96,14 @@ falkordb.query\_result module
 -----------------------------
 
 .. automodule:: falkordb.query_result
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+falkordb.sentinel module
+-------------------------
+
+.. automodule:: falkordb.sentinel
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
## Summary
Fixes missing/empty API sections in the published Sphinx docs (https://falkordb-py.readthedocs.io) and adds documentation entries for modules that were never wired into the `.rst` toctree.

## Changes
- **`docs/requirements.txt`**: Added `python-dateutil>=2.9.0`. `falkordb/query_result.py` imports `dateutil.relativedelta`, but Read the Docs only installs packages listed in `docs/requirements.txt`. Without it, Sphinx autodoc's import of `falkordb.query_result` (and transitively `falkordb.graph`, `falkordb.falkordb`) silently fails, rendering those sections with headings but **no content** on the live site (verified by reproducing the RTD build in a clean venv).
- **`docs/source/falkordb.rst`**: Added missing `falkordb.cluster` and `falkordb.sentinel` automodule entries.
- **`docs/source/falkordb.asyncio.rst`**: Added missing `falkordb.asyncio.cluster` automodule entry.
- **`.gitignore`**: Ignore local `docs/_build/` output.

## Testing
- Reproduced the RTD build environment in a clean virtualenv using only `docs/requirements.txt` (pre-fix): confirmed `ModuleNotFoundError: No module named 'dateutil'` during autodoc import of `falkordb.query_result`, and confirmed the generated HTML lacked `id="module-falkordb.query_result"` (only had the empty heading anchor).
- Re-ran the build after adding `python-dateutil`: build succeeded, and all 12 top-level modules (`cluster`, `edge`, `exceptions`, `execution_plan`, `falkordb`, `graph`, `graph_schema`, `helpers`, `node`, `path`, `query_result`, `sentinel`) now produce the `module-falkordb.*` anchor, confirming autodoc imported and documented them correctly, including `QueryResult`.
- Also ran a full local `sphinx-build -b html docs/source docs/_build` — build succeeded with only pre-existing, unrelated docstring-indentation warnings in `falkordb.py`/`helpers.py`.

## Memory / Performance Impact
N/A — documentation-only change.

## Related Issues
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation to cover cluster and sentinel functionality.
  * Added documentation for asynchronous cluster features.
  * Included additional documentation tooling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->