### PR TITLE
fix: only forward accepted kwargs from Is_Cluster to redis.Redis

### DIFF
--- a/falkordb/asyncio/cluster.py
+++ b/falkordb/asyncio/cluster.py
@@ -1,3 +1,4 @@
+import inspect
 import socket
 
 import redis as sync_redis  # type: ignore[import-not-found]
@@ -21,6 +22,13 @@ def Is_Cluster(conn: redis.Redis):
     # Translate the key so the sync probe can be built for unix:// connections.
     if pool.connection_class is redis.UnixDomainSocketConnection:
         kwargs["unix_socket_path"] = kwargs.pop("path")
+
+    # Keep only the parameters the synchronous constructor actually accepts.
+    # redis-py stores internal state in ``connection_kwargs`` that is not part
+    # of the ``Redis.__init__`` signature — redis 8.1.0 added ``himport_registry``
+    # there — and forwarding those raises TypeError before any I/O happens.
+    accepted = inspect.signature(sync_redis.Redis.__init__).parameters
+    kwargs = {k: v for k, v in kwargs.items() if k in accepted}
 
     # Create a synchronous Redis client with the same parameters
     # as the connection pool just to keep Is_Cluster synchronous

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -350,3 +351,38 @@ async def test_udf_flush(async_client):
     # Verify all UDFs are removed
     udfs = await db.udf_list()
     assert udfs == []
+
+
+def test_is_cluster_filters_unknown_connection_kwargs():
+    """``Is_Cluster`` must not forward pool kwargs that ``redis.Redis`` rejects.
+
+    redis-py keeps internal state in ``connection_kwargs`` that is not part of
+    the ``Redis.__init__`` signature — 8.1.0 added ``himport_registry`` and
+    several ``maint_notifications_*`` entries — and forwarding them raises
+    ``TypeError`` before any command is sent. ``Is_Cluster`` runs during
+    connection setup, so that breaks every async query.
+
+    The real ``Redis.__init__`` is exercised here (only ``info()`` is stubbed),
+    since rejecting the kwargs is precisely what used to fail.
+    """
+    from redis.asyncio import ConnectionPool
+
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    pool = ConnectionPool(host="localhost", port=6379, decode_responses=True)
+    # Pin the behaviour on redis versions that don't inject anything yet.
+    pool.connection_kwargs["himport_registry"] = object()
+
+    conn = SimpleNamespace(connection_pool=pool)
+
+    with patch(
+        "falkordb.asyncio.cluster.sync_redis.Redis.info",
+        return_value={"redis_mode": "standalone"},
+    ):
+        assert Is_Cluster(conn) is False
+
+    with patch(
+        "falkordb.asyncio.cluster.sync_redis.Redis.info",
+        return_value={"redis_mode": "cluster"},
+    ):
+        assert Is_Cluster(conn) is True


### PR DESCRIPTION
Fixes #261.

## Problem

The async client can't run a single query against redis >= 8.1.0:

```
TypeError: Redis.__init__() got an unexpected keyword argument 'himport_registry'
```

What happens:

```
You call FalkorDB(...)
   ↓
Setup needs to know: is this a cluster or one server?
   ↓
calls Is_Cluster()
   ↓
to ask the server it needs a client, so it builds a temporary sync Redis
from the pool's connection_kwargs
   ↓
that dict is the argument set for Connection, and 8.1.0 added six fields to it:
himport_registry, maint_notifications_pool_handler, maint_notifications_config,
orig_host_address, orig_socket_timeout, orig_socket_connect_timeout
   ↓
Redis.__init__ accepts none of them → TypeError on himport_registry, the first one it hits
   ↓
FalkorDB(...) raises. No client is ever returned.
```

`connection_kwargs` is the argument set for `Connection`, not for `Redis` — redis-py builds connections with it directly:

```python
connection = self.connection_class(**self.connection_kwargs)
```

So the entries are legitimate connection parameters, they're just addressed to a different constructor. The two signatures overlap on the common fields (`host`, `port`, `db`, `ssl`, ...), which is why forwarding the dict worked for as long as it did. 8.1.0 added six parameters that `AbstractConnection` accepts and `Redis` does not, and the overlap stopped holding. `himport_registry` is simply the first one hit — each of the other five fails the same way.

Because the probe runs during connection setup, this raises before any command is sent — so it kills **every async query**, not just cluster deployments.

| client | redis 8.0.1 | redis 8.1.0 |
|---|---|---|
| `falkordb.FalkorDB` | works | works |
| `falkordb.asyncio.FalkorDB` | works | unusable |

The sync client is unaffected: `falkordb/cluster.py` picks fields out by name instead of forwarding the whole dict.

Since `redis` is declared as `>=7.1.0` with no upper bound, a plain `pip install falkordb` resolves 8.1.0 and the async client is broken out of the box.

## Fix

Filter the kwargs against the `Redis.__init__` signature before forwarding.

I went with a signature filter rather than dropping `himport_registry` by name, because:

- 8.1.0 adds six such keys, not one — name-blocking is whack-a-mole
- this is a repeat of issue #235, which was the same crash in the same call with `path`. That was fixed by special-casing that one key, and redis shipped new `Connection` parameters 11 days later. A signature filter covers both and anything added later.

The `path` -> `unix_socket_path` translation is kept and still runs **before** the filter. It has to: `path` is not an accepted `Redis` parameter name, so if the filter ran first it would drop the key outright and the probe would silently connect over TCP to the default host instead of the unix socket. A quiet misconnect is worse than the `TypeError` this PR removes, so the rename can't be folded into the filter.

## Test

Builds a real async pool, injects an unknown key, and drives `Is_Cluster` through both the standalone and cluster branches.

Only `info()` is stubbed — the real `Redis.__init__` runs, since rejecting the extra kwargs is exactly what used to raise. Patching the whole class would hide the regression, because the filter reads the constructor signature and would then see the mock's.

The unknown key is injected explicitly rather than relying on the installed redis version, so this keeps guarding the behaviour on redis < 8.1.0.

Verified by reverting the fix commit: the test fails with the reported `TypeError`.

## Checks

- Test fails without the fix, passes with it
- Against redis 8.1.0 locally the suite goes from **31 failed / 63 passed** to **5 failed / 96 passed**
- The 5 remaining are the UDF tests plus `test_graph_creation`, unrelated to this change — they assert on a response shape the server no longer returns, and were previously unreachable because the client couldn't connect at all
- Should also turn #258 (the Dependabot redis bump) green

## Note on CI

The red matrix jobs are pre-existing and not caused by this PR. `main` without this change produces the same signature — 19 failed / 48 passed / 33 errors — versus 19 failed / **49** passed / 33 errors here, the extra pass being the test this PR adds.

Reproduced locally against `falkordb/falkordb:edge`: the failures are engine changes the tests haven't caught up to (the `Results` root operation is gone, `Merge` plans now root at `Commit`, traverse direction flipped and `Join` became `Union`, and `GRAPH.SLOWLOG` returns empty). falkordb-ts is aligning the same assertions in its #609.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster-mode detection by ignoring unsupported internal connection parameters.
  * Prevented connection checks from failing when unexpected pool options are provided.

* **Tests**
  * Added regression coverage for connection-parameter filtering in standalone and cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
