### PR TITLE
style: format README Python code blocks for ruff 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,23 @@ Or use [FalkorDB Cloud](https://app.falkordb.cloud)
 from falkordb import FalkorDB
 
 # Connect to FalkorDB
-db = FalkorDB(host='localhost', port=6379)
+db = FalkorDB(host="localhost", port=6379)
 
 # Select the social graph
-g = db.select_graph('social')
+g = db.select_graph("social")
 
 # Create 100 nodes and return a handful
-nodes = g.query('UNWIND range(0, 100) AS i CREATE (n {v:1}) RETURN n LIMIT 10').result_set
+nodes = g.query(
+    "UNWIND range(0, 100) AS i CREATE (n {v:1}) RETURN n LIMIT 10"
+).result_set
 for n in nodes:
     print(n)
 
 # Read-only query the graph for the first 10 nodes
-nodes = g.ro_query('MATCH (n) RETURN n LIMIT 10').result_set
+nodes = g.ro_query("MATCH (n) RETURN n LIMIT 10").result_set
 
 # Copy the Graph
-copy_graph = g.copy('social_copy')
+copy_graph = g.copy("social_copy")
 
 # Delete the Graph
 g.delete()
@@ -60,38 +62,44 @@ import asyncio
 from falkordb.asyncio import FalkorDB
 from redis.asyncio import BlockingConnectionPool
 
+
 async def main():
 
     # Connect to FalkorDB
-    pool = BlockingConnectionPool(max_connections=16, timeout=None, decode_responses=True)
+    pool = BlockingConnectionPool(
+        max_connections=16, timeout=None, decode_responses=True
+    )
     db = FalkorDB(connection_pool=pool)
-    
+
     # Select the social graph
-    g = db.select_graph('social')
-    
+    g = db.select_graph("social")
+
     # Execute query asynchronously
-    result = await g.query('UNWIND range(0, 100) AS i CREATE (n {v:1}) RETURN n LIMIT 10')
-    
+    result = await g.query(
+        "UNWIND range(0, 100) AS i CREATE (n {v:1}) RETURN n LIMIT 10"
+    )
+
     # Process results
     for n in result.result_set:
         print(n)
-    
+
     # Run multiple queries concurrently
     tasks = [
-        g.query('MATCH (n) WHERE n.v = 1 RETURN count(n) AS count'),
+        g.query("MATCH (n) WHERE n.v = 1 RETURN count(n) AS count"),
         g.query('CREATE (p:Person {name: "Alice"}) RETURN p'),
-        g.query('CREATE (p:Person {name: "Bob"}) RETURN p')
+        g.query('CREATE (p:Person {name: "Bob"}) RETURN p'),
     ]
-    
+
     results = await asyncio.gather(*tasks)
-    
+
     # Process concurrent results
     print(f"Node count: {results[0].result_set[0][0]}")
     print(f"Created Alice: {results[1].result_set[0][0]}")
     print(f"Created Bob: {results[2].result_set[0][0]}")
-    
+
     # Close the connection when done
     await pool.aclose()
+
 
 # Run the async example
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`Lint` is failing on `main`: ruff 0.16 formats Python code blocks embedded in Markdown, and `README.md` predates that behaviour. The ruff `0.15.4 -> 0.16.2` bump (#260) therefore turned `ruff format --check .` red.

## Changes
- Reformat the Python snippets in `README.md` (double quotes, line wrapping, blank lines). No semantic change to any example.

## Testing
```
uv run ruff format --check .   # 43 files already formatted
uv run ruff check .            # All checks passed!
uv run mypy falkordb/          # Success: no issues found in 20 source files
```

## Memory / Performance Impact
N/A — documentation formatting only.

## Related Issues
Follow-up to #260.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized quotation marks in synchronous and asynchronous examples.
  * Reformatted longer connection-pool and query calls for improved readability.
  * Clarified example formatting without changing execution flow or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->