### PR TITLE
build: bound dependencies to tested versions, release 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "FalkorDB"
-version = "1.6.2"
+version = "1.7.0"
 description = "Python client for interacting with FalkorDB database"
 authors = [
     {name = "FalkorDB inc", email = "info@falkordb.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "redis>=7.1.0",
-    "python-dateutil>=2.9.0",
+    # Bounded to the versions this client is tested against. Raise the upper
+    # bounds once a newer release has been verified against the test suite.
+    # Lower bound is 7.2: falkordb imports redis.driver_info, added in 7.2.
+    "redis>=7.2,<8.2",
+    "python-dateutil>=2.9.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -357,8 +357,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
-    { name = "python-dateutil", specifier = ">=2.9.0" },
-    { name = "redis", specifier = ">=7.1.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0,<3" },
+    { name = "redis", specifier = ">=7.2,<8.2" },
 ]
 provides-extras = ["test"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "falkordb"
-version = "1.6.2"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
## What

Two commits:

1. **`build:`** — bound `redis` and `python-dateutil` to the versions this client is tested against
2. **`chore(release):`** — bump to `1.7.0`

```diff
 dependencies = [
-    "redis>=7.1.0",
-    "python-dateutil>=2.9.0",
+    "redis>=7.2,<8.2",
+    "python-dateutil>=2.9.0,<3",
 ]
```

## Why

Both dependencies had a lower bound only, so a fresh `pip install falkordb` always resolved to whatever was newest on PyPI. Nothing in this repo decided that — PyPI did.

That is exactly how redis 8.1 reached users: it added five pool-only keyword arguments to `ConnectionPool.connection_kwargs`, `Is_Cluster()` forwarded them to the synchronous `redis.Redis()` constructor, and every async client died with `TypeError: Redis.__init__() got an unexpected keyword argument 'himport_registry'` before a single query ran. Fixed in #262, but it reached users first because nothing constrained the resolve.

Our `uv.lock` pins redis 7.4.0, which is why CI stayed green throughout — the lockfile governs this repo's own CI and nothing downstream. Consumers only ever see the range in `pyproject.toml`.

### The lower bound was also wrong

`falkordb/falkordb.py:4` does `from redis.driver_info import DriverInfo`. That module first appears in redis **7.2**, so `>=7.1.0` advertised a floor that fails on import. Raised to `>=7.2`.

### Why 1.7.0 and not 1.6.3

The bug fixes alone would be a patch, but narrowing the redis range changes which environments can install the client, which is more than a patch should do.

Since 1.6.2:
- **fix:** `Is_Cluster()` no longer forwards pool-only kwargs to `redis.Redis` (#262)
- **fix:** the execution plan parser attaches every sibling operation to its parent rather than nesting siblings under each other (#267)
- **build:** dependency bounds (this PR)

## Tradeoff worth naming

Upper bounds on a library are not free. If a user installs `falkordb` alongside a package that requires `redis>=8.2`, pip cannot satisfy both and the install fails with `ResolutionImpossible` — and there is nothing the user can do except wait for a release from us. That is the cost we are accepting in exchange for never shipping an untested transitive version again.

Two things keep that cost small:

- `<8.2` still allows redis 8.1.x, which is current, so no one is held back today
- #271 already runs the suite against the newest redis daily, so we learn about a new release from CI rather than from an issue

The bound should be raised as a routine chore whenever that daily job passes on a newer version — not left to drift until it blocks someone.

## Testing

- `103 passed` against `falkordb/falkordb:edge`
- fresh `pip install .` resolves redis **8.1.0** — inside the new bound, and working with #262
- `uv sync --extra test` leaves `uv.lock` unmodified

`uv.lock` carries only the three lines that had to change (the `falkordb` version and the two specifier strings). Note it was generated by a newer `uv` than 0.7.19 — running `uv lock` on an older uv rewrites `revision = 3` to `2` and drops a `python_full_version < '3.13'` marker, so it was hand-edited to keep the diff honest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to version 1.7.0.
  * Refined supported version ranges for Redis and `python-dateutil` to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->