### PR TITLE
fix(schema): refresh GraphSchema cache on query execution to prevent stale property key mappings (#243)

### DIFF
--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -81,6 +81,9 @@ class AsyncGraph(Graph):
 
         # issue query
         try:
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = await self.execute_command(*command)
             query_result = QueryResult(self)
             await query_result.parse(response)

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -81,9 +81,10 @@ class AsyncGraph(Graph):
 
         # issue query
         try:
-            self.schema._dirty_labels = True
-            self.schema._dirty_properties = True
-            self.schema._dirty_relations = True
+            if not read_only:
+                self.schema._dirty_labels = True
+                self.schema._dirty_properties = True
+                self.schema._dirty_relations = True
             response = await self.execute_command(*command)
             query_result = QueryResult(self)
             await query_result.parse(response)

--- a/falkordb/asyncio/graph_schema.py
+++ b/falkordb/asyncio/graph_schema.py
@@ -112,11 +112,7 @@ class GraphSchema:
 
         if self._dirty_labels or not self.labels or idx >= len(self.labels):
             await self.refresh_labels()
-        try:
-            return self.labels[idx]
-        except IndexError:
-            await self.refresh_labels()
-            return self.labels[idx]
+        return self.labels[idx]
 
     async def get_relation(self, idx: int) -> str:
         """
@@ -136,11 +132,7 @@ class GraphSchema:
             or idx >= len(self.relationships)
         ):
             await self.refresh_relations()
-        try:
-            return self.relationships[idx]
-        except IndexError:
-            await self.refresh_relations()
-            return self.relationships[idx]
+        return self.relationships[idx]
 
     async def get_property(self, idx: int) -> str:
         """
@@ -156,8 +148,4 @@ class GraphSchema:
 
         if self._dirty_properties or not self.properties or idx >= len(self.properties):
             await self.refresh_properties()
-        try:
-            return self.properties[idx]
-        except IndexError:
-            await self.refresh_properties()
-            return self.properties[idx]
+        return self.properties[idx]

--- a/falkordb/asyncio/graph_schema.py
+++ b/falkordb/asyncio/graph_schema.py
@@ -37,6 +37,9 @@ class GraphSchema:
         self.labels = []
         self.properties = []
         self.relationships = []
+        self._dirty_labels = True
+        self._dirty_properties = True
+        self._dirty_relations = True
 
     async def refresh_labels(self) -> None:
         """
@@ -49,6 +52,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_LABELS)).result_set
         self.labels = [label[0] for label in result_set]
+        self._dirty_labels = False
 
     async def refresh_relations(self) -> None:
         """
@@ -61,6 +65,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_RELATIONSHIPTYPES)).result_set
         self.relationships = [r[0] for r in result_set]
+        self._dirty_relations = False
 
     async def refresh_properties(self) -> None:
         """
@@ -73,6 +78,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_PROPERTYKEYS)).result_set
         self.properties = [p[0] for p in result_set]
+        self._dirty_properties = False
 
     async def refresh(self, version: int) -> None:
         """
@@ -104,13 +110,13 @@ class GraphSchema:
 
         """
 
-        try:
-            label = self.labels[idx]
-        except IndexError:
-            # refresh labels
+        if self._dirty_labels or not self.labels or idx >= len(self.labels):
             await self.refresh_labels()
-            label = self.labels[idx]
-        return label
+        try:
+            return self.labels[idx]
+        except IndexError:
+            await self.refresh_labels()
+            return self.labels[idx]
 
     async def get_relation(self, idx: int) -> str:
         """
@@ -124,13 +130,17 @@ class GraphSchema:
 
         """
 
-        try:
-            r = self.relationships[idx]
-        except IndexError:
-            # refresh relationship types
+        if (
+            self._dirty_relations
+            or not self.relationships
+            or idx >= len(self.relationships)
+        ):
             await self.refresh_relations()
-            r = self.relationships[idx]
-        return r
+        try:
+            return self.relationships[idx]
+        except IndexError:
+            await self.refresh_relations()
+            return self.relationships[idx]
 
     async def get_property(self, idx: int) -> str:
         """
@@ -144,10 +154,10 @@ class GraphSchema:
 
         """
 
-        try:
-            p = self.properties[idx]
-        except IndexError:
-            # refresh properties
+        if self._dirty_properties or not self.properties or idx >= len(self.properties):
             await self.refresh_properties()
-            p = self.properties[idx]
-        return p
+        try:
+            return self.properties[idx]
+        except IndexError:
+            await self.refresh_properties()
+            return self.properties[idx]

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -94,9 +94,10 @@ class Graph:
 
         # issue query
         try:
-            self.schema._dirty_labels = True
-            self.schema._dirty_properties = True
-            self.schema._dirty_relations = True
+            if not read_only:
+                self.schema._dirty_labels = True
+                self.schema._dirty_properties = True
+                self.schema._dirty_relations = True
             response = self.execute_command(*command)
             return QueryResult(self, response)
         except SchemaVersionMismatchException as e:

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -94,6 +94,9 @@ class Graph:
 
         # issue query
         try:
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = self.execute_command(*command)
             return QueryResult(self, response)
         except SchemaVersionMismatchException as e:

--- a/falkordb/graph_schema.py
+++ b/falkordb/graph_schema.py
@@ -37,6 +37,9 @@ class GraphSchema:
         self.labels = []
         self.properties = []
         self.relationships = []
+        self._dirty_labels = True
+        self._dirty_properties = True
+        self._dirty_relations = True
 
     def refresh_labels(self) -> None:
         """
@@ -49,6 +52,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_LABELS).result_set
         self.labels = [label[0] for label in result_set]
+        self._dirty_labels = False
 
     def refresh_relations(self) -> None:
         """
@@ -61,6 +65,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_RELATIONSHIPTYPES).result_set
         self.relationships = [r[0] for r in result_set]
+        self._dirty_relations = False
 
     def refresh_properties(self) -> None:
         """
@@ -73,6 +78,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_PROPERTYKEYS).result_set
         self.properties = [p[0] for p in result_set]
+        self._dirty_properties = False
 
     def refresh(self, version: int) -> None:
         """
@@ -104,13 +110,13 @@ class GraphSchema:
 
         """
 
-        try:
-            label = self.labels[idx]
-        except IndexError:
-            # refresh labels
+        if self._dirty_labels or not self.labels or idx >= len(self.labels):
             self.refresh_labels()
-            label = self.labels[idx]
-        return label
+        try:
+            return self.labels[idx]
+        except IndexError:
+            self.refresh_labels()
+            return self.labels[idx]
 
     def get_relation(self, idx: int) -> str:
         """
@@ -124,13 +130,17 @@ class GraphSchema:
 
         """
 
-        try:
-            r = self.relationships[idx]
-        except IndexError:
-            # refresh relationship types
+        if (
+            self._dirty_relations
+            or not self.relationships
+            or idx >= len(self.relationships)
+        ):
             self.refresh_relations()
-            r = self.relationships[idx]
-        return r
+        try:
+            return self.relationships[idx]
+        except IndexError:
+            self.refresh_relations()
+            return self.relationships[idx]
 
     def get_property(self, idx: int) -> str:
         """
@@ -144,10 +154,10 @@ class GraphSchema:
 
         """
 
-        try:
-            p = self.properties[idx]
-        except IndexError:
-            # refresh properties
+        if self._dirty_properties or not self.properties or idx >= len(self.properties):
             self.refresh_properties()
-            p = self.properties[idx]
-        return p
+        try:
+            return self.properties[idx]
+        except IndexError:
+            self.refresh_properties()
+            return self.properties[idx]

--- a/falkordb/graph_schema.py
+++ b/falkordb/graph_schema.py
@@ -112,11 +112,7 @@ class GraphSchema:
 
         if self._dirty_labels or not self.labels or idx >= len(self.labels):
             self.refresh_labels()
-        try:
-            return self.labels[idx]
-        except IndexError:
-            self.refresh_labels()
-            return self.labels[idx]
+        return self.labels[idx]
 
     def get_relation(self, idx: int) -> str:
         """
@@ -136,11 +132,7 @@ class GraphSchema:
             or idx >= len(self.relationships)
         ):
             self.refresh_relations()
-        try:
-            return self.relationships[idx]
-        except IndexError:
-            self.refresh_relations()
-            return self.relationships[idx]
+        return self.relationships[idx]
 
     def get_property(self, idx: int) -> str:
         """
@@ -156,8 +148,4 @@ class GraphSchema:
 
         if self._dirty_properties or not self.properties or idx >= len(self.properties):
             self.refresh_properties()
-        try:
-            return self.properties[idx]
-        except IndexError:
-            self.refresh_properties()
-            return self.properties[idx]
+        return self.properties[idx]

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -588,3 +588,53 @@ async def test_explain():
 
     # close the connection pool
     await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_schema_cache_on_external_delete(async_client):
+    g = async_client
+    gname = g.name
+    db = g.client
+
+    # Phase 1: Build graph A with property order [id, name, color, size]
+    await g.query(
+        "CREATE (n:Item) SET n.id='i1', n.name='Widget', n.color='red', n.size=10"
+    )
+    res = await g.query("MATCH (n:Item) RETURN n")
+    assert res.result_set[0][0].properties == {
+        "id": "i1",
+        "name": "Widget",
+        "color": "red",
+        "size": 10,
+    }
+
+    # Phase 2: External delete (raw GRAPH.DELETE, bypassing Graph.delete())
+    await db.connection.execute_command("GRAPH.DELETE", gname)
+
+    # Phase 3: Recreate graph B under same name with different
+    # property registration order
+    g_new = db.select_graph(gname)
+    await g_new.query(
+        "CREATE (n:Item) SET n.id='i2', n.size=20, n.color='blue', n.name='Gadget'"
+    )
+
+    # Phase 4: Read using existing Graph object and verify compact format
+    # returns correct properties
+    res_compact = await g.query("MATCH (n:Item) RETURN n")
+    compact = res_compact.result_set[0][0].properties
+
+    res_map = await g.query("MATCH (n:Item) RETURN properties(n)")
+    correct = dict(res_map.result_set[0][0])
+
+    assert (
+        compact
+        == correct
+        == {
+            "id": "i2",
+            "size": 20,
+            "color": "blue",
+            "name": "Gadget",
+        }
+    )
+
+    await g_new.delete()

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -591,10 +591,18 @@ async def test_explain():
 
 
 @pytest.mark.asyncio
-async def test_async_schema_cache_on_external_delete(async_client):
-    g = async_client
-    gname = g.name
-    db = g.client
+async def test_async_schema_cache_on_external_delete():
+    pool = BlockingConnectionPool(
+        max_connections=16, timeout=None, decode_responses=True
+    )
+    db = FalkorDB(connection_pool=pool)
+    gname = "async_external_delete_schema_test"
+    g = db.select_graph(gname)
+
+    try:
+        await db.connection.execute_command("GRAPH.DELETE", gname)
+    except Exception:
+        pass
 
     # Phase 1: Build graph A with property order [id, name, color, size]
     await g.query(
@@ -638,3 +646,4 @@ async def test_async_schema_cache_on_external_delete(async_client):
     )
 
     await g_new.delete()
+    await pool.aclose()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -549,3 +549,50 @@ def test_explain(client):
     )
 
     g.delete()
+
+
+def test_schema_cache_on_external_delete(client):
+    g = client
+    gname = g.name
+    db = g.client
+
+    # Phase 1: Build graph A with property order [id, name, color, size]
+    g.query("CREATE (n:Item) SET n.id='i1', n.name='Widget', n.color='red', n.size=10")
+    res = g.query("MATCH (n:Item) RETURN n")
+    assert res.result_set[0][0].properties == {
+        "id": "i1",
+        "name": "Widget",
+        "color": "red",
+        "size": 10,
+    }
+
+    # Phase 2: External delete (raw GRAPH.DELETE, bypassing Graph.delete())
+    db.connection.execute_command("GRAPH.DELETE", gname)
+
+    # Phase 3: Recreate graph B under same name with different
+    # property registration order
+    g_new = db.select_graph(gname)
+    g_new.query(
+        "CREATE (n:Item) SET n.id='i2', n.size=20, n.color='blue', n.name='Gadget'"
+    )
+
+    # Phase 4: Read using existing Graph object and verify compact format
+    # returns correct properties
+    res_compact = g.query("MATCH (n:Item) RETURN n")
+    compact = res_compact.result_set[0][0].properties
+
+    res_map = g.query("MATCH (n:Item) RETURN properties(n)")
+    correct = dict(res_map.result_set[0][0])
+
+    assert (
+        compact
+        == correct
+        == {
+            "id": "i2",
+            "size": 20,
+            "color": "blue",
+            "name": "Gadget",
+        }
+    )
+
+    g_new.delete()


### PR DESCRIPTION
Fixes #243

### Problem
When a graph is deleted externally (e.g. raw `GRAPH.DELETE`, process crash, or another client worker) without calling `Graph.delete()` on a Python `Graph` instance, `GraphSchema` retains stale property key mappings from the old graph. If a new graph is created under the same name with a different property key registration order, `RETURN n` (compact format) silently maps property IDs to incorrect property names, returning corrupted data.

### Solution
1. **Independent Dirty Tracking**: Added `_dirty_labels`, `_dirty_properties`, and `_dirty_relations` flags to `GraphSchema` (sync & async).
2. **Query Execution Marking**: Set dirty flags on query execution in `Graph._query` and `AsyncGraph._query`.
3. **On-Demand Cache Refresh**: Updated `get_property()`, `get_label()`, and `get_relation()` to automatically fetch up-to-date schema metadata (`DB.PROPERTYKEYS`) on demand when dirty.
4. **Regression Tests**: Added unit tests `test_schema_cache_on_external_delete` in `tests/test_graph.py` and `test_async_schema_cache_on_external_delete` in `tests/test_async_graph.py`.

### Verification
Ran regression test suite. `RETURN n` and `RETURN properties(n)` now match 100%. All pre-commit checks (`ruff format`, `ruff check`, `mypy falkordb/`) passed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema cache refresh behavior after graph changes, deletion, or recreation.
  * Ensured label, property, and relationship metadata refresh independently when stale or unavailable.
  * Preserved schema state during read-only queries while refreshing it after updates.
  * Fixed property lookups when a graph is recreated with a different property registration order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->