### PR TITLE
feat: add replica connection support and fix silent crash on query timeout

### DIFF
--- a/falkordb/asyncio/cluster.py
+++ b/falkordb/asyncio/cluster.py
@@ -35,6 +35,13 @@ def Is_Cluster(conn: redis.Redis):
         info = sync_redis.Redis(**kwargs).info(section="server")
 
         return "redis_mode" in info and info["redis_mode"] == "cluster"
+    except (
+        ConnectionError,
+        ConnectionRefusedError,
+        OSError,
+        sync_redis.exceptions.ConnectionError,
+    ):
+        raise
     except Exception:
         return False
 
@@ -71,12 +78,14 @@ def parse_cluster_slots(raw_slots):
                 r_host = _str_val(r_info[0])
                 r_port = int(r_info[1])
                 r_id = _str_val(r_info[2]) if len(r_info) > 2 else f"{r_host}:{r_port}"
-                replicas.append({
-                    "id": r_id,
-                    "host": r_host,
-                    "port": r_port,
-                    "endpoint": f"{r_host}:{r_port}",
-                })
+                replicas.append(
+                    {
+                        "id": r_id,
+                        "host": r_host,
+                        "port": r_port,
+                        "endpoint": f"{r_host}:{r_port}",
+                    }
+                )
 
             shards_map[primary_key] = {
                 "primary": {

--- a/falkordb/asyncio/cluster.py
+++ b/falkordb/asyncio/cluster.py
@@ -9,32 +9,89 @@ from redis.asyncio.cluster import RedisCluster  # type: ignore[import-not-found]
 
 # detect if a connection is a cluster
 def Is_Cluster(conn: redis.Redis):
+    try:
+        pool = conn.connection_pool
+        kwargs = pool.connection_kwargs.copy()
 
-    pool = conn.connection_pool
-    kwargs = pool.connection_kwargs.copy()
+        # Check if the connection is using SSL and add it
+        # this propery is not kept in the connection_kwargs
+        kwargs["ssl"] = pool.connection_class is redis.SSLConnection
 
-    # Check if the connection is using SSL and add it
-    # this propery is not kept in the connection_kwargs
-    kwargs["ssl"] = pool.connection_class is redis.SSLConnection
+        # The async Unix-domain-socket pool stores the socket path under "path",
+        # but the synchronous redis.Redis constructor expects "unix_socket_path".
+        # Translate the key so the sync probe can be built for unix:// connections.
+        if pool.connection_class is redis.UnixDomainSocketConnection:
+            kwargs["unix_socket_path"] = kwargs.pop("path")
 
-    # The async Unix-domain-socket pool stores the socket path under "path",
-    # but the synchronous redis.Redis constructor expects "unix_socket_path".
-    # Translate the key so the sync probe can be built for unix:// connections.
-    if pool.connection_class is redis.UnixDomainSocketConnection:
-        kwargs["unix_socket_path"] = kwargs.pop("path")
+        # Keep only the parameters the synchronous constructor actually accepts.
+        # redis-py stores internal state in ``connection_kwargs`` that is not part
+        # of the ``Redis.__init__`` signature — redis 8.1.0 added ``himport_registry``
+        # there — and forwarding those raises TypeError before any I/O happens.
+        accepted = inspect.signature(sync_redis.Redis.__init__).parameters
+        kwargs = {k: v for k, v in kwargs.items() if k in accepted}
 
-    # Keep only the parameters the synchronous constructor actually accepts.
-    # redis-py stores internal state in ``connection_kwargs`` that is not part
-    # of the ``Redis.__init__`` signature — redis 8.1.0 added ``himport_registry``
-    # there — and forwarding those raises TypeError before any I/O happens.
-    accepted = inspect.signature(sync_redis.Redis.__init__).parameters
-    kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+        # Create a synchronous Redis client with the same parameters
+        # as the connection pool just to keep Is_Cluster synchronous
+        info = sync_redis.Redis(**kwargs).info(section="server")
 
-    # Create a synchronous Redis client with the same parameters
-    # as the connection pool just to keep Is_Cluster synchronous
-    info = sync_redis.Redis(**kwargs).info(section="server")
+        return "redis_mode" in info and info["redis_mode"] == "cluster"
+    except Exception:
+        return False
 
-    return "redis_mode" in info and info["redis_mode"] == "cluster"
+
+def _str_val(v):
+    if isinstance(v, bytes):
+        return v.decode("utf-8")
+    return str(v)
+
+
+def parse_cluster_slots(raw_slots):
+    """
+    Parses CLUSTER SLOTS output into a list of primary and replica shard mappings.
+    """
+    shards_map = {}
+
+    for item in raw_slots:
+        if not item or len(item) < 3:
+            continue
+        start_slot = int(item[0])
+        end_slot = int(item[1])
+
+        p_info = item[2]
+        p_host = _str_val(p_info[0])
+        p_port = int(p_info[1])
+        p_id = _str_val(p_info[2]) if len(p_info) > 2 else f"{p_host}:{p_port}"
+
+        primary_key = (p_host, p_port)
+        if primary_key not in shards_map:
+            replicas = []
+            for r_info in item[3:]:
+                if not r_info or len(r_info) < 2:
+                    continue
+                r_host = _str_val(r_info[0])
+                r_port = int(r_info[1])
+                r_id = _str_val(r_info[2]) if len(r_info) > 2 else f"{r_host}:{r_port}"
+                replicas.append({
+                    "id": r_id,
+                    "host": r_host,
+                    "port": r_port,
+                    "endpoint": f"{r_host}:{r_port}",
+                })
+
+            shards_map[primary_key] = {
+                "primary": {
+                    "id": p_id,
+                    "host": p_host,
+                    "port": p_port,
+                    "endpoint": f"{p_host}:{p_port}",
+                },
+                "replicas": replicas,
+                "slots": [(start_slot, end_slot)],
+            }
+        else:
+            shards_map[primary_key]["slots"].append((start_slot, end_slot))
+
+    return list(shards_map.values())
 
 
 # create a cluster connection from a Redis connection

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -4,9 +4,12 @@ import redis.asyncio as redis  # type: ignore[import-not-found]
 from redis.driver_info import DriverInfo
 from redis.exceptions import RedisError
 
+from redis.asyncio.cluster import RedisCluster  # type: ignore[import-not-found]
+
 from .._version import get_package_version
 from .cluster import Cluster_Conn, Is_Cluster
 from .graph import AsyncGraph
+from .sentinel import Is_Sentinel, Sentinel_Conn
 
 # config command
 UDF_CMD = "GRAPH.UDF"
@@ -115,6 +118,16 @@ class FalkorDB:
             protocol=protocol,
         )
 
+        self.sentinel = None
+        self.service_name = None
+
+        if Is_Sentinel(conn):
+            self.sentinel, self.service_name = Sentinel_Conn(conn, ssl)
+            if read_from_replicas:
+                conn = self.sentinel.slave_for(self.service_name, ssl=ssl)
+            else:
+                conn = self.sentinel.master_for(self.service_name, ssl=ssl)
+
         if Is_Cluster(conn):
             conn = Cluster_Conn(
                 conn,
@@ -130,6 +143,30 @@ class FalkorDB:
         self.connection = conn
         self.flushdb = conn.flushdb
         self.execute_command = conn.execute_command
+
+    def get_replica_connection(self) -> Union[redis.Redis, RedisCluster]:
+        """
+        Returns a connection instance configured to read from replicas.
+
+        In Sentinel mode: Returns a connection to a Sentinel slave/replica.
+        In Cluster mode: Returns a cluster connection with read_from_replicas=True.
+        In Standalone mode: Returns the underlying connection.
+        """
+        if self.sentinel is not None:
+            return self.sentinel.slave_for(self.service_name)
+
+        if Is_Cluster(self.connection):
+            if isinstance(self.connection, RedisCluster):
+                return self.connection
+            return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
+
+        return self.connection
+
+    async def _disconnect_connection(self):
+        """
+        Disconnects the underlying connection or pool to clear dirty socket state.
+        """
+        await self.connection.aclose()
 
     @classmethod
     def from_url(cls, url: str, **kwargs) -> "FalkorDB":

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -166,7 +166,10 @@ class FalkorDB:
         """
         Disconnects the underlying connection or pool to clear dirty socket state.
         """
-        await self.connection.aclose()
+        try:
+            await self.connection.aclose()
+        except (RedisError, OSError):
+            pass
 
     @classmethod
     def from_url(cls, url: str, **kwargs) -> "FalkorDB":
@@ -267,8 +270,8 @@ class FalkorDB:
 
         try:
             await self.connection.aclose()
-        except RedisError:
-            # best-effort close — don't raise on Redis errors
+        except (RedisError, OSError):
+            # best-effort close — don't raise on Redis or socket errors
             pass
 
     async def __aenter__(self) -> "FalkorDB":

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -117,8 +117,9 @@ class FalkorDB:
             protocol=protocol,
         )
 
-        self.sentinel = None
-        self.service_name = None
+        self._raw_conn = conn
+        self._ssl = ssl
+        self._replica_connection = None
 
         if Is_Sentinel(conn):
             self.sentinel, self.service_name = Sentinel_Conn(conn, ssl)
@@ -156,14 +157,21 @@ class FalkorDB:
 
         if Is_Cluster(self.connection):
             if isinstance(self.connection, RedisCluster):
-                return self.connection
+                if getattr(self.connection, "read_from_replicas", False):
+                    return self.connection
+                if self._replica_connection is None:
+                    self._replica_connection = Cluster_Conn(
+                        self._raw_conn, ssl=self._ssl, read_from_replicas=True
+                    )
+                return self._replica_connection
             return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
 
         return self.connection
 
     async def get_cluster_shards(self) -> List[Dict[str, Any]]:
         """
-        Deduces and returns FalkorDB Cluster shards asynchronously, mapping primary nodes to their replicas.
+        Deduces and returns FalkorDB Cluster shards asynchronously,
+        mapping primary nodes to their replicas.
         """
         if Is_Cluster(self.connection):
             raw_slots = await self.connection.execute_command("CLUSTER", "SLOTS")
@@ -174,7 +182,12 @@ class FalkorDB:
         port = kwargs.get("port", 6379)
         return [
             {
-                "primary": {"id": "standalone", "host": host, "port": port, "endpoint": f"{host}:{port}"},
+                "primary": {
+                    "id": "standalone",
+                    "host": host,
+                    "port": port,
+                    "endpoint": f"{host}:{port}",
+                },
                 "replicas": [],
                 "slots": [(0, 16383)],
             }

--- a/falkordb/asyncio/falkordb.py
+++ b/falkordb/asyncio/falkordb.py
@@ -1,13 +1,12 @@
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import redis.asyncio as redis  # type: ignore[import-not-found]
+from redis.asyncio.cluster import RedisCluster  # type: ignore[import-not-found]
 from redis.driver_info import DriverInfo
 from redis.exceptions import RedisError
 
-from redis.asyncio.cluster import RedisCluster  # type: ignore[import-not-found]
-
 from .._version import get_package_version
-from .cluster import Cluster_Conn, Is_Cluster
+from .cluster import Cluster_Conn, Is_Cluster, parse_cluster_slots
 from .graph import AsyncGraph
 from .sentinel import Is_Sentinel, Sentinel_Conn
 
@@ -161,6 +160,25 @@ class FalkorDB:
             return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
 
         return self.connection
+
+    async def get_cluster_shards(self) -> List[Dict[str, Any]]:
+        """
+        Deduces and returns FalkorDB Cluster shards asynchronously, mapping primary nodes to their replicas.
+        """
+        if Is_Cluster(self.connection):
+            raw_slots = await self.connection.execute_command("CLUSTER", "SLOTS")
+            return parse_cluster_slots(raw_slots)
+
+        kwargs = self.connection.connection_pool.connection_kwargs
+        host = kwargs.get("host", "localhost")
+        port = kwargs.get("port", 6379)
+        return [
+            {
+                "primary": {"id": "standalone", "host": host, "port": port, "endpoint": f"{host}:{port}"},
+                "replicas": [],
+                "slots": [(0, 16383)],
+            }
+        ]
 
     async def _disconnect_connection(self):
         """

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -81,6 +81,9 @@ class AsyncGraph(Graph):
 
         # issue query
         try:
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = await self.execute_command(*command)
             query_result = QueryResult(self)
             await query_result.parse(response)

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -94,6 +94,16 @@ class AsyncGraph(Graph):
             # set client version and refresh local schema
             await self.schema.refresh(e.version)
             raise e
+        except Exception as e:
+            if "timed out" in str(e).lower() or "timeout" in str(e).lower():
+                await self._disconnect_connection()
+            raise e
+
+    async def _disconnect_connection(self):
+        """
+        Disconnects the underlying client connection to purge dirty socket state after a timeout.
+        """
+        await self.client._disconnect_connection()
 
     async def query(  # type: ignore[override]
         self,

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -101,7 +101,8 @@ class AsyncGraph(Graph):
 
     async def _disconnect_connection(self):
         """
-        Disconnects the underlying client connection to purge dirty socket state after a timeout.
+        Disconnects the underlying client connection
+        to purge dirty socket state after a timeout.
         """
         await self.client._disconnect_connection()
 

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -81,9 +81,10 @@ class AsyncGraph(Graph):
 
         # issue query
         try:
-            self.schema._dirty_labels = True
-            self.schema._dirty_properties = True
-            self.schema._dirty_relations = True
+            if not read_only:
+                self.schema._dirty_labels = True
+                self.schema._dirty_properties = True
+                self.schema._dirty_relations = True
             response = await self.execute_command(*command)
             query_result = QueryResult(self)
             await query_result.parse(response)

--- a/falkordb/asyncio/graph.py
+++ b/falkordb/asyncio/graph.py
@@ -81,10 +81,9 @@ class AsyncGraph(Graph):
 
         # issue query
         try:
-            if not read_only:
-                self.schema._dirty_labels = True
-                self.schema._dirty_properties = True
-                self.schema._dirty_relations = True
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = await self.execute_command(*command)
             query_result = QueryResult(self)
             await query_result.parse(response)

--- a/falkordb/asyncio/graph_schema.py
+++ b/falkordb/asyncio/graph_schema.py
@@ -112,11 +112,7 @@ class GraphSchema:
 
         if self._dirty_labels or not self.labels or idx >= len(self.labels):
             await self.refresh_labels()
-        try:
-            return self.labels[idx]
-        except IndexError:
-            await self.refresh_labels()
-            return self.labels[idx]
+        return self.labels[idx]
 
     async def get_relation(self, idx: int) -> str:
         """
@@ -136,11 +132,7 @@ class GraphSchema:
             or idx >= len(self.relationships)
         ):
             await self.refresh_relations()
-        try:
-            return self.relationships[idx]
-        except IndexError:
-            await self.refresh_relations()
-            return self.relationships[idx]
+        return self.relationships[idx]
 
     async def get_property(self, idx: int) -> str:
         """
@@ -156,8 +148,4 @@ class GraphSchema:
 
         if self._dirty_properties or not self.properties or idx >= len(self.properties):
             await self.refresh_properties()
-        try:
-            return self.properties[idx]
-        except IndexError:
-            await self.refresh_properties()
-            return self.properties[idx]
+        return self.properties[idx]

--- a/falkordb/asyncio/graph_schema.py
+++ b/falkordb/asyncio/graph_schema.py
@@ -37,6 +37,9 @@ class GraphSchema:
         self.labels = []
         self.properties = []
         self.relationships = []
+        self._dirty_labels = True
+        self._dirty_properties = True
+        self._dirty_relations = True
 
     async def refresh_labels(self) -> None:
         """
@@ -49,6 +52,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_LABELS)).result_set
         self.labels = [label[0] for label in result_set]
+        self._dirty_labels = False
 
     async def refresh_relations(self) -> None:
         """
@@ -61,6 +65,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_RELATIONSHIPTYPES)).result_set
         self.relationships = [r[0] for r in result_set]
+        self._dirty_relations = False
 
     async def refresh_properties(self) -> None:
         """
@@ -73,6 +78,7 @@ class GraphSchema:
 
         result_set = (await self.graph.call_procedure(DB_PROPERTYKEYS)).result_set
         self.properties = [p[0] for p in result_set]
+        self._dirty_properties = False
 
     async def refresh(self, version: int) -> None:
         """
@@ -104,13 +110,13 @@ class GraphSchema:
 
         """
 
-        try:
-            label = self.labels[idx]
-        except IndexError:
-            # refresh labels
+        if self._dirty_labels or not self.labels or idx >= len(self.labels):
             await self.refresh_labels()
-            label = self.labels[idx]
-        return label
+        try:
+            return self.labels[idx]
+        except IndexError:
+            await self.refresh_labels()
+            return self.labels[idx]
 
     async def get_relation(self, idx: int) -> str:
         """
@@ -124,13 +130,17 @@ class GraphSchema:
 
         """
 
-        try:
-            r = self.relationships[idx]
-        except IndexError:
-            # refresh relationship types
+        if (
+            self._dirty_relations
+            or not self.relationships
+            or idx >= len(self.relationships)
+        ):
             await self.refresh_relations()
-            r = self.relationships[idx]
-        return r
+        try:
+            return self.relationships[idx]
+        except IndexError:
+            await self.refresh_relations()
+            return self.relationships[idx]
 
     async def get_property(self, idx: int) -> str:
         """
@@ -144,10 +154,10 @@ class GraphSchema:
 
         """
 
-        try:
-            p = self.properties[idx]
-        except IndexError:
-            # refresh properties
+        if self._dirty_properties or not self.properties or idx >= len(self.properties):
             await self.refresh_properties()
-            p = self.properties[idx]
-        return p
+        try:
+            return self.properties[idx]
+        except IndexError:
+            await self.refresh_properties()
+            return self.properties[idx]

--- a/falkordb/asyncio/sentinel.py
+++ b/falkordb/asyncio/sentinel.py
@@ -7,19 +7,22 @@ from redis.asyncio.sentinel import Sentinel  # type: ignore[import-not-found]
 
 # detect if a connection is a sentinel
 def Is_Sentinel(conn: redis.Redis) -> bool:
-    pool = conn.connection_pool
-    kwargs = pool.connection_kwargs.copy()
+    try:
+        pool = conn.connection_pool
+        kwargs = pool.connection_kwargs.copy()
 
-    kwargs["ssl"] = pool.connection_class is redis.SSLConnection
+        kwargs["ssl"] = pool.connection_class is redis.SSLConnection
 
-    if pool.connection_class is redis.UnixDomainSocketConnection:
-        kwargs["unix_socket_path"] = kwargs.pop("path")
+        if pool.connection_class is redis.UnixDomainSocketConnection:
+            kwargs["unix_socket_path"] = kwargs.pop("path")
 
-    accepted = inspect.signature(sync_redis.Redis.__init__).parameters
-    kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+        accepted = inspect.signature(sync_redis.Redis.__init__).parameters
+        kwargs = {k: v for k, v in kwargs.items() if k in accepted}
 
-    info = sync_redis.Redis(**kwargs).info(section="server")
-    return "redis_mode" in info and info["redis_mode"] == "sentinel"
+        info = sync_redis.Redis(**kwargs).info(section="server")
+        return "redis_mode" in info and info["redis_mode"] == "sentinel"
+    except Exception:
+        return False
 
 
 # create an async sentinel connection from a Redis connection

--- a/falkordb/asyncio/sentinel.py
+++ b/falkordb/asyncio/sentinel.py
@@ -1,0 +1,61 @@
+import inspect
+
+import redis as sync_redis  # type: ignore[import-not-found]
+import redis.asyncio as redis  # type: ignore[import-not-found]
+from redis.asyncio.sentinel import Sentinel  # type: ignore[import-not-found]
+
+
+# detect if a connection is a sentinel
+def Is_Sentinel(conn: redis.Redis) -> bool:
+    pool = conn.connection_pool
+    kwargs = pool.connection_kwargs.copy()
+
+    kwargs["ssl"] = pool.connection_class is redis.SSLConnection
+
+    if pool.connection_class is redis.UnixDomainSocketConnection:
+        kwargs["unix_socket_path"] = kwargs.pop("path")
+
+    accepted = inspect.signature(sync_redis.Redis.__init__).parameters
+    kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+
+    info = sync_redis.Redis(**kwargs).info(section="server")
+    return "redis_mode" in info and info["redis_mode"] == "sentinel"
+
+
+# create an async sentinel connection from a Redis connection
+def Sentinel_Conn(conn: redis.Redis, ssl: bool):
+    pool = conn.connection_pool
+    kwargs = pool.connection_kwargs.copy()
+
+    kwargs["ssl"] = pool.connection_class is redis.SSLConnection
+
+    if pool.connection_class is redis.UnixDomainSocketConnection:
+        kwargs["unix_socket_path"] = kwargs.pop("path")
+
+    accepted = inspect.signature(sync_redis.Redis.__init__).parameters
+    probe_kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+
+    sync_conn = sync_redis.Redis(**probe_kwargs)
+    masters = sync_conn.sentinel_masters()
+
+    if len(masters) != 1:
+        raise Exception("Multiple masters, require service name")
+
+    service_name = list(masters.keys())[0]
+
+    host = kwargs.get("host", "localhost")
+    port = kwargs.get("port", 6379)
+    sentinels_conns = [(host, port)]
+
+    sentinel_kwargs = {}
+    if "username" in kwargs:
+        sentinel_kwargs["username"] = kwargs["username"]
+    if "password" in kwargs:
+        sentinel_kwargs["password"] = kwargs["password"]
+    if ssl:
+        sentinel_kwargs["ssl"] = True
+
+    return (
+        Sentinel(sentinels_conns, sentinel_kwargs=sentinel_kwargs, **kwargs),
+        service_name,
+    )

--- a/falkordb/asyncio/sentinel.py
+++ b/falkordb/asyncio/sentinel.py
@@ -21,6 +21,13 @@ def Is_Sentinel(conn: redis.Redis) -> bool:
 
         info = sync_redis.Redis(**kwargs).info(section="server")
         return "redis_mode" in info and info["redis_mode"] == "sentinel"
+    except (
+        ConnectionError,
+        ConnectionRefusedError,
+        OSError,
+        sync_redis.exceptions.ConnectionError,
+    ):
+        raise
     except Exception:
         return False
 

--- a/falkordb/cluster.py
+++ b/falkordb/cluster.py
@@ -6,8 +6,66 @@ from redis.cluster import RedisCluster  # type: ignore[import-not-found]
 
 # detect if a connection is a Cluster
 def Is_Cluster(conn):
-    info = conn.info(section="server")
-    return "redis_mode" in info and info["redis_mode"] == "cluster"
+    try:
+        info = conn.info(section="server")
+        return "redis_mode" in info and info["redis_mode"] == "cluster"
+    except Exception:
+        return False
+
+
+def _str_val(v):
+    if isinstance(v, bytes):
+        return v.decode("utf-8")
+    return str(v)
+
+
+def parse_cluster_slots(raw_slots):
+    """
+    Parses CLUSTER SLOTS output into a list of primary and replica shard mappings.
+    """
+    shards_map = {}
+
+    for item in raw_slots:
+        if not item or len(item) < 3:
+            continue
+        start_slot = int(item[0])
+        end_slot = int(item[1])
+
+        p_info = item[2]
+        p_host = _str_val(p_info[0])
+        p_port = int(p_info[1])
+        p_id = _str_val(p_info[2]) if len(p_info) > 2 else f"{p_host}:{p_port}"
+
+        primary_key = (p_host, p_port)
+        if primary_key not in shards_map:
+            replicas = []
+            for r_info in item[3:]:
+                if not r_info or len(r_info) < 2:
+                    continue
+                r_host = _str_val(r_info[0])
+                r_port = int(r_info[1])
+                r_id = _str_val(r_info[2]) if len(r_info) > 2 else f"{r_host}:{r_port}"
+                replicas.append({
+                    "id": r_id,
+                    "host": r_host,
+                    "port": r_port,
+                    "endpoint": f"{r_host}:{r_port}",
+                })
+
+            shards_map[primary_key] = {
+                "primary": {
+                    "id": p_id,
+                    "host": p_host,
+                    "port": p_port,
+                    "endpoint": f"{p_host}:{p_port}",
+                },
+                "replicas": replicas,
+                "slots": [(start_slot, end_slot)],
+            }
+        else:
+            shards_map[primary_key]["slots"].append((start_slot, end_slot))
+
+    return list(shards_map.values())
 
 
 # create a cluster connection from a Redis connection

--- a/falkordb/cluster.py
+++ b/falkordb/cluster.py
@@ -9,6 +9,13 @@ def Is_Cluster(conn):
     try:
         info = conn.info(section="server")
         return "redis_mode" in info and info["redis_mode"] == "cluster"
+    except (
+        ConnectionError,
+        ConnectionRefusedError,
+        OSError,
+        redis_exceptions.ConnectionError,
+    ):
+        raise
     except Exception:
         return False
 
@@ -45,12 +52,14 @@ def parse_cluster_slots(raw_slots):
                 r_host = _str_val(r_info[0])
                 r_port = int(r_info[1])
                 r_id = _str_val(r_info[2]) if len(r_info) > 2 else f"{r_host}:{r_port}"
-                replicas.append({
-                    "id": r_id,
-                    "host": r_host,
-                    "port": r_port,
-                    "endpoint": f"{r_host}:{r_port}",
-                })
+                replicas.append(
+                    {
+                        "id": r_id,
+                        "host": r_host,
+                        "port": r_port,
+                        "endpoint": f"{r_host}:{r_port}",
+                    }
+                )
 
             shards_map[primary_key] = {
                 "primary": {

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -180,7 +180,10 @@ class FalkorDB:
         """
         Disconnects the underlying connection or pool to clear dirty socket state.
         """
-        self.connection.close()
+        try:
+            self.connection.close()
+        except (RedisError, OSError):
+            pass
 
     @classmethod
     def from_url(cls, url: str, **kwargs) -> "FalkorDB":

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -130,8 +130,9 @@ class FalkorDB:
             protocol=protocol,
         )
 
-        self.sentinel = None
-        self.service_name = None
+        self._raw_conn = conn
+        self._ssl = ssl
+        self._replica_connection = None
 
         if Is_Sentinel(conn):
             self.sentinel, self.service_name = Sentinel_Conn(conn, ssl)
@@ -171,14 +172,21 @@ class FalkorDB:
 
         if Is_Cluster(self.connection):
             if isinstance(self.connection, RedisCluster):
-                return self.connection
+                if getattr(self.connection, "read_from_replicas", False):
+                    return self.connection
+                if self._replica_connection is None:
+                    self._replica_connection = Cluster_Conn(
+                        self._raw_conn, ssl=self._ssl, read_from_replicas=True
+                    )
+                return self._replica_connection
             return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
 
         return self.connection
 
     def get_cluster_shards(self) -> List[Dict[str, Any]]:
         """
-        Deduces and returns FalkorDB Cluster shards, mapping primary nodes to their replicas.
+        Deduces and returns FalkorDB Cluster shards,
+        mapping primary nodes to their replicas.
         """
         if Is_Cluster(self.connection):
             raw_slots = self.connection.execute_command("CLUSTER", "SLOTS")
@@ -189,7 +197,12 @@ class FalkorDB:
         port = kwargs.get("port", 6379)
         return [
             {
-                "primary": {"id": "standalone", "host": host, "port": port, "endpoint": f"{host}:{port}"},
+                "primary": {
+                    "id": "standalone",
+                    "host": host,
+                    "port": port,
+                    "endpoint": f"{host}:{port}",
+                },
                 "replicas": [],
                 "slots": [(0, 16383)],
             }

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union
 
 import redis  # type: ignore[import-not-found]
+from redis.cluster import RedisCluster  # type: ignore[import-not-found]
 from redis.driver_info import DriverInfo
 from redis.exceptions import RedisError
 
@@ -129,9 +130,15 @@ class FalkorDB:
             protocol=protocol,
         )
 
+        self.sentinel = None
+        self.service_name = None
+
         if Is_Sentinel(conn):
             self.sentinel, self.service_name = Sentinel_Conn(conn, ssl)
-            conn = self.sentinel.master_for(self.service_name, ssl=ssl)
+            if read_from_replicas:
+                conn = self.sentinel.slave_for(self.service_name, ssl=ssl)
+            else:
+                conn = self.sentinel.master_for(self.service_name, ssl=ssl)
 
         if Is_Cluster(conn):
             conn = Cluster_Conn(
@@ -150,6 +157,30 @@ class FalkorDB:
         self.connection = conn
         self.flushdb = conn.flushdb
         self.execute_command = conn.execute_command
+
+    def get_replica_connection(self) -> Union[redis.Redis, RedisCluster]:
+        """
+        Returns a connection instance configured to read from replicas.
+
+        In Sentinel mode: Returns a connection to a Sentinel slave/replica.
+        In Cluster mode: Returns a cluster connection with read_from_replicas=True.
+        In Standalone mode: Returns the underlying connection.
+        """
+        if self.sentinel is not None:
+            return self.sentinel.slave_for(self.service_name)
+
+        if Is_Cluster(self.connection):
+            if isinstance(self.connection, RedisCluster):
+                return self.connection
+            return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
+
+        return self.connection
+
+    def _disconnect_connection(self):
+        """
+        Disconnects the underlying connection or pool to clear dirty socket state.
+        """
+        self.connection.close()
 
     @classmethod
     def from_url(cls, url: str, **kwargs) -> "FalkorDB":

--- a/falkordb/falkordb.py
+++ b/falkordb/falkordb.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import redis  # type: ignore[import-not-found]
 from redis.cluster import RedisCluster  # type: ignore[import-not-found]
@@ -6,7 +6,7 @@ from redis.driver_info import DriverInfo
 from redis.exceptions import RedisError
 
 from ._version import get_package_version
-from .cluster import Cluster_Conn, Is_Cluster
+from .cluster import Cluster_Conn, Is_Cluster, parse_cluster_slots
 from .graph import Graph
 from .sentinel import Is_Sentinel, Sentinel_Conn
 
@@ -175,6 +175,25 @@ class FalkorDB:
             return Cluster_Conn(self.connection, ssl=False, read_from_replicas=True)
 
         return self.connection
+
+    def get_cluster_shards(self) -> List[Dict[str, Any]]:
+        """
+        Deduces and returns FalkorDB Cluster shards, mapping primary nodes to their replicas.
+        """
+        if Is_Cluster(self.connection):
+            raw_slots = self.connection.execute_command("CLUSTER", "SLOTS")
+            return parse_cluster_slots(raw_slots)
+
+        kwargs = self.connection.connection_pool.connection_kwargs
+        host = kwargs.get("host", "localhost")
+        port = kwargs.get("port", 6379)
+        return [
+            {
+                "primary": {"id": "standalone", "host": host, "port": port, "endpoint": f"{host}:{port}"},
+                "replicas": [],
+                "slots": [(0, 16383)],
+            }
+        ]
 
     def _disconnect_connection(self):
         """

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -105,6 +105,16 @@ class Graph:
             # set client version and refresh local schema
             self.schema.refresh(e.version)
             raise e
+        except Exception as e:
+            if "timed out" in str(e).lower() or "timeout" in str(e).lower():
+                self._disconnect_connection()
+            raise e
+
+    def _disconnect_connection(self):
+        """
+        Disconnects the underlying client connection to purge dirty socket state after a timeout.
+        """
+        self.client._disconnect_connection()
 
     def query(
         self,

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -94,9 +94,10 @@ class Graph:
 
         # issue query
         try:
-            self.schema._dirty_labels = True
-            self.schema._dirty_properties = True
-            self.schema._dirty_relations = True
+            if not read_only:
+                self.schema._dirty_labels = True
+                self.schema._dirty_properties = True
+                self.schema._dirty_relations = True
             response = self.execute_command(*command)
             return QueryResult(self, response)
         except SchemaVersionMismatchException as e:

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -94,6 +94,9 @@ class Graph:
 
         # issue query
         try:
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = self.execute_command(*command)
             return QueryResult(self, response)
         except SchemaVersionMismatchException as e:

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -112,7 +112,8 @@ class Graph:
 
     def _disconnect_connection(self):
         """
-        Disconnects the underlying client connection to purge dirty socket state after a timeout.
+        Disconnects the underlying client connection
+        to purge dirty socket state after a timeout.
         """
         self.client._disconnect_connection()
 

--- a/falkordb/graph.py
+++ b/falkordb/graph.py
@@ -94,10 +94,9 @@ class Graph:
 
         # issue query
         try:
-            if not read_only:
-                self.schema._dirty_labels = True
-                self.schema._dirty_properties = True
-                self.schema._dirty_relations = True
+            self.schema._dirty_labels = True
+            self.schema._dirty_properties = True
+            self.schema._dirty_relations = True
             response = self.execute_command(*command)
             return QueryResult(self, response)
         except SchemaVersionMismatchException as e:

--- a/falkordb/graph_schema.py
+++ b/falkordb/graph_schema.py
@@ -37,6 +37,9 @@ class GraphSchema:
         self.labels = []
         self.properties = []
         self.relationships = []
+        self._dirty_labels = True
+        self._dirty_properties = True
+        self._dirty_relations = True
 
     def refresh_labels(self) -> None:
         """
@@ -49,6 +52,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_LABELS).result_set
         self.labels = [label[0] for label in result_set]
+        self._dirty_labels = False
 
     def refresh_relations(self) -> None:
         """
@@ -61,6 +65,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_RELATIONSHIPTYPES).result_set
         self.relationships = [r[0] for r in result_set]
+        self._dirty_relations = False
 
     def refresh_properties(self) -> None:
         """
@@ -73,6 +78,7 @@ class GraphSchema:
 
         result_set = self.graph.call_procedure(DB_PROPERTYKEYS).result_set
         self.properties = [p[0] for p in result_set]
+        self._dirty_properties = False
 
     def refresh(self, version: int) -> None:
         """
@@ -104,13 +110,13 @@ class GraphSchema:
 
         """
 
-        try:
-            label = self.labels[idx]
-        except IndexError:
-            # refresh labels
+        if self._dirty_labels or not self.labels or idx >= len(self.labels):
             self.refresh_labels()
-            label = self.labels[idx]
-        return label
+        try:
+            return self.labels[idx]
+        except IndexError:
+            self.refresh_labels()
+            return self.labels[idx]
 
     def get_relation(self, idx: int) -> str:
         """
@@ -124,13 +130,17 @@ class GraphSchema:
 
         """
 
-        try:
-            r = self.relationships[idx]
-        except IndexError:
-            # refresh relationship types
+        if (
+            self._dirty_relations
+            or not self.relationships
+            or idx >= len(self.relationships)
+        ):
             self.refresh_relations()
-            r = self.relationships[idx]
-        return r
+        try:
+            return self.relationships[idx]
+        except IndexError:
+            self.refresh_relations()
+            return self.relationships[idx]
 
     def get_property(self, idx: int) -> str:
         """
@@ -144,10 +154,10 @@ class GraphSchema:
 
         """
 
-        try:
-            p = self.properties[idx]
-        except IndexError:
-            # refresh properties
+        if self._dirty_properties or not self.properties or idx >= len(self.properties):
             self.refresh_properties()
-            p = self.properties[idx]
-        return p
+        try:
+            return self.properties[idx]
+        except IndexError:
+            self.refresh_properties()
+            return self.properties[idx]

--- a/falkordb/graph_schema.py
+++ b/falkordb/graph_schema.py
@@ -112,11 +112,7 @@ class GraphSchema:
 
         if self._dirty_labels or not self.labels or idx >= len(self.labels):
             self.refresh_labels()
-        try:
-            return self.labels[idx]
-        except IndexError:
-            self.refresh_labels()
-            return self.labels[idx]
+        return self.labels[idx]
 
     def get_relation(self, idx: int) -> str:
         """
@@ -136,11 +132,7 @@ class GraphSchema:
             or idx >= len(self.relationships)
         ):
             self.refresh_relations()
-        try:
-            return self.relationships[idx]
-        except IndexError:
-            self.refresh_relations()
-            return self.relationships[idx]
+        return self.relationships[idx]
 
     def get_property(self, idx: int) -> str:
         """
@@ -156,8 +148,4 @@ class GraphSchema:
 
         if self._dirty_properties or not self.properties or idx >= len(self.properties):
             self.refresh_properties()
-        try:
-            return self.properties[idx]
-        except IndexError:
-            self.refresh_properties()
-            return self.properties[idx]
+        return self.properties[idx]

--- a/falkordb/sentinel.py
+++ b/falkordb/sentinel.py
@@ -1,3 +1,4 @@
+import redis.exceptions as redis_exceptions
 from redis.sentinel import Sentinel  # type: ignore[import-not-found]
 
 
@@ -6,6 +7,13 @@ def Is_Sentinel(conn):
     try:
         info = conn.info(section="server")
         return "redis_mode" in info and info["redis_mode"] == "sentinel"
+    except (
+        ConnectionError,
+        ConnectionRefusedError,
+        OSError,
+        redis_exceptions.ConnectionError,
+    ):
+        raise
     except Exception:
         return False
 

--- a/falkordb/sentinel.py
+++ b/falkordb/sentinel.py
@@ -3,8 +3,11 @@ from redis.sentinel import Sentinel  # type: ignore[import-not-found]
 
 # detect if a connection is a sentinel
 def Is_Sentinel(conn):
-    info = conn.info(section="server")
-    return "redis_mode" in info and info["redis_mode"] == "sentinel"
+    try:
+        info = conn.info(section="server")
+        return "redis_mode" in info and info["redis_mode"] == "sentinel"
+    except Exception:
+        return False
 
 
 # create a sentinel connection from a Redis connection

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -26,6 +26,7 @@ async def async_client():
 def test_driver_info_version(kwargs, expected_version):
     with (
         patch("falkordb.asyncio.falkordb.redis.Redis") as mock_redis,
+        patch("falkordb.asyncio.falkordb.Is_Sentinel", return_value=False),
         patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=False),
         patch(
             "falkordb.asyncio.falkordb.get_package_version",
@@ -134,8 +135,9 @@ async def test_from_url():
 
 
 @pytest.mark.asyncio
+@patch("falkordb.asyncio.falkordb.Is_Sentinel", return_value=False)
 @patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=False)
-async def test_from_url_unix_socket(mock_cluster):
+async def test_from_url_unix_socket(mock_sentinel, mock_cluster):
     """Test that from_url correctly parses unix:// socket URLs."""
     db = FalkorDB.from_url("unix:///tmp/falkordb.sock")
     pool = db.connection.connection_pool
@@ -148,8 +150,9 @@ async def test_from_url_unix_socket(mock_cluster):
 
 
 @pytest.mark.asyncio
+@patch("falkordb.asyncio.falkordb.Is_Sentinel", return_value=False)
 @patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=False)
-async def test_from_url_unix_socket_with_password(mock_cluster):
+async def test_from_url_unix_socket_with_password(mock_sentinel, mock_cluster):
     """Test that from_url handles unix:// URLs with credentials."""
     db = FalkorDB.from_url("unix://myuser:mypass@/tmp/falkordb.sock?db=2")
     pool = db.connection.connection_pool

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -628,10 +628,10 @@ async def test_async_schema_cache_on_external_delete():
 
     # Phase 4: Read using existing Graph object and verify compact format
     # returns correct properties
-    res_compact = await g.query("MATCH (n:Item) RETURN n")
+    res_compact = await g.ro_query("MATCH (n:Item) RETURN n")
     compact = res_compact.result_set[0][0].properties
 
-    res_map = await g.query("MATCH (n:Item) RETURN properties(n)")
+    res_map = await g.ro_query("MATCH (n:Item) RETURN properties(n)")
     correct = dict(res_map.result_set[0][0])
 
     assert (

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -588,3 +588,53 @@ async def test_explain():
 
     # close the connection pool
     await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_schema_cache_on_external_delete(async_client):
+    g = async_client
+    gname = g.name
+    db = g.client
+
+    # Phase 1: Build graph A with property order [id, name, color, size]
+    await g.query(
+        "CREATE (n:Item) SET n.id='i1', n.name='Widget', n.color='red', n.size=10"
+    )
+    res = await g.query("MATCH (n:Item) RETURN n")
+    assert res.result_set[0][0].properties == {
+        "id": "i1",
+        "name": "Widget",
+        "color": "red",
+        "size": 10,
+    }
+
+    # Phase 2: External delete (raw GRAPH.DELETE, bypassing Graph.delete())
+    await db.connection.execute_command("GRAPH.DELETE", gname)
+
+    # Phase 3: Recreate graph B under same name with different
+    # property registration order
+    g_new = db.select_graph(gname)
+    await g_new.query(
+        "CREATE (n:Item) SET n.id='i2', n.size=20, n.color='blue', n.name='Gadget'"
+    )
+
+    # Phase 4: Read using existing Graph object and verify compact format
+    # returns correct properties
+    res_compact = await g.query("MATCH (n:Item) RETURN n")
+    compact = res_compact.result_set[0][0].properties
+
+    res_map = await g.query("MATCH (n:Item) RETURN properties(n)")
+    correct = dict(res_map.result_set[0][0])
+
+    assert (
+        compact
+        == correct
+        == {
+            "id": "i2",
+            "size": 20,
+            "color": "blue",
+            "name": "Gadget",
+        }
+    )
+
+    await g_new.delete()

--- a/tests/test_async_graph.py
+++ b/tests/test_async_graph.py
@@ -591,10 +591,18 @@ async def test_explain():
 
 
 @pytest.mark.asyncio
-async def test_async_schema_cache_on_external_delete(async_client):
-    g = async_client
-    gname = g.name
-    db = g.client
+async def test_async_schema_cache_on_external_delete():
+    pool = BlockingConnectionPool(
+        max_connections=16, timeout=None, decode_responses=True
+    )
+    db = FalkorDB(connection_pool=pool)
+    gname = "async_external_delete_schema_test"
+    g = db.select_graph(gname)
+
+    try:
+        await db.connection.execute_command("GRAPH.DELETE", gname)
+    except Exception:
+        pass
 
     # Phase 1: Build graph A with property order [id, name, color, size]
     await g.query(
@@ -638,3 +646,4 @@ async def test_async_schema_cache_on_external_delete(async_client):
     )
 
     await g_new.delete()
+    await pool.aclose()

--- a/tests/test_async_timeout_recovery.py
+++ b/tests/test_async_timeout_recovery.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from redis.exceptions import ResponseError
+
+from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+
+
+@pytest.mark.asyncio
+async def test_async_query_timeout_disconnects_unhealthy_connection():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+
+    async def async_exec(*args, **kwargs):
+        if mock_conn.execute_command.call_count == 1:
+            raise ResponseError("Query timed out")
+        return [
+            [[1, b"header"]],
+            [[[3, b"1"]]],
+            [b"Query internal execution time: 0.1 milliseconds"],
+        ]
+
+    mock_conn.execute_command = MagicMock(side_effect=async_exec)
+    mock_conn.aclose = AsyncMock()
+
+    db.connection = mock_conn
+    db.execute_command = mock_conn.execute_command
+
+    graph = db.select_graph("async_test_timeout_graph")
+
+    # First query triggers query timeout
+    with pytest.raises(ResponseError) as exc_info:
+        await graph.query("MATCH (n) RETURN n")
+    assert "Query timed out" in str(exc_info.value)
+
+    # Connection aclose should have been called
+    mock_conn.aclose.assert_called_once()
+
+    # Second query succeeds on fresh connection
+    res = await graph.query("RETURN 1")
+    assert res is not None

--- a/tests/test_cluster_shards.py
+++ b/tests/test_cluster_shards.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
+from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+from falkordb.cluster import parse_cluster_slots
+
+
+def test_parse_cluster_slots():
+    raw_slots = [
+        [0, 5460, [b"127.0.0.1", 6379, b"node_primary_1"], [b"127.0.0.1", 6380, b"node_replica_1"]],
+        [5461, 10922, [b"127.0.0.1", 6381, b"node_primary_2"], [b"127.0.0.1", 6382, b"node_replica_2"]],
+    ]
+    shards = parse_cluster_slots(raw_slots)
+    assert len(shards) == 2
+
+    shard1 = shards[0]
+    assert shard1["primary"]["id"] == "node_primary_1"
+    assert shard1["primary"]["host"] == "127.0.0.1"
+    assert shard1["primary"]["port"] == 6379
+    assert len(shard1["replicas"]) == 1
+    assert shard1["replicas"][0]["id"] == "node_replica_1"
+    assert shard1["replicas"][0]["port"] == 6380
+    assert shard1["slots"] == [(0, 5460)]
+
+    shard2 = shards[1]
+    assert shard2["primary"]["id"] == "node_primary_2"
+    assert shard2["primary"]["port"] == 6381
+    assert shard2["replicas"][0]["port"] == 6382
+
+
+def test_sync_get_cluster_shards():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    raw_slots = [
+        [0, 16383, [b"10.0.0.1", 6379, b"p1"], [b"10.0.0.2", 6379, b"r1"]],
+    ]
+    mock_conn.execute_command.return_value = raw_slots
+    db.connection = mock_conn
+
+    with patch("falkordb.falkordb.Is_Cluster", return_value=True):
+        shards = db.get_cluster_shards()
+        assert len(shards) == 1
+        assert shards[0]["primary"]["host"] == "10.0.0.1"
+        assert shards[0]["replicas"][0]["host"] == "10.0.0.2"
+
+
+def test_sync_get_cluster_shards_standalone():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "127.0.0.1", "port": 6379}
+    db.connection = mock_conn
+
+    with patch("falkordb.falkordb.Is_Cluster", return_value=False):
+        shards = db.get_cluster_shards()
+        assert len(shards) == 1
+        assert shards[0]["primary"]["host"] == "127.0.0.1"
+        assert shards[0]["primary"]["port"] == 6379
+
+
+@pytest.mark.asyncio
+async def test_async_get_cluster_shards():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    raw_slots = [
+        [0, 16383, [b"10.0.0.1", 6379, b"p1"], [b"10.0.0.2", 6379, b"r1"]],
+    ]
+
+    async def async_exec(*args, **kwargs):
+        return raw_slots
+
+    mock_conn.execute_command = MagicMock(side_effect=async_exec)
+    db.connection = mock_conn
+
+    with patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True):
+        shards = await db.get_cluster_shards()
+        assert len(shards) == 1
+        assert shards[0]["primary"]["host"] == "10.0.0.1"
+        assert shards[0]["replicas"][0]["host"] == "10.0.0.2"

--- a/tests/test_cluster_shards.py
+++ b/tests/test_cluster_shards.py
@@ -94,3 +94,142 @@ async def test_async_get_cluster_shards():
         assert len(shards) == 1
         assert shards[0]["primary"]["host"] == "10.0.0.1"
         assert shards[0]["replicas"][0]["host"] == "10.0.0.2"
+
+
+def test_sync_is_cluster_true():
+    from falkordb.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.info.return_value = {"redis_mode": "cluster"}
+    assert Is_Cluster(mock_conn) is True
+
+
+def test_sync_is_cluster_false():
+    from falkordb.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.info.return_value = {"redis_mode": "standalone"}
+    assert Is_Cluster(mock_conn) is False
+
+
+def test_sync_is_cluster_generic_exception():
+    from falkordb.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.info.side_effect = ValueError("unexpected error")
+    assert Is_Cluster(mock_conn) is False
+
+
+def test_sync_is_cluster_connection_error_raises():
+    from falkordb.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.info.side_effect = ConnectionError("failed connect")
+    with pytest.raises(ConnectionError):
+        Is_Cluster(mock_conn)
+
+
+def test_async_is_cluster_true():
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 6379}
+    with patch("falkordb.asyncio.cluster.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "cluster"}
+        assert Is_Cluster(mock_conn) is True
+
+
+def test_async_is_cluster_false():
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 6379}
+    with patch("falkordb.asyncio.cluster.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "standalone"}
+        assert Is_Cluster(mock_conn) is False
+
+
+def test_async_is_cluster_generic_exception():
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 6379}
+    with patch("falkordb.asyncio.cluster.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.side_effect = ValueError("error")
+        assert Is_Cluster(mock_conn) is False
+
+
+def test_sync_cluster_conn():
+    from falkordb.cluster import Cluster_Conn
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "username": "user",
+        "password": "pass",
+    }
+    with patch("falkordb.cluster.RedisCluster") as mock_cluster_cls:
+        Cluster_Conn(mock_conn, ssl=False, read_from_replicas=True)
+        mock_cluster_cls.assert_called_once()
+
+
+def test_async_cluster_conn():
+    from falkordb.asyncio.cluster import Cluster_Conn
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {
+        "host": "localhost",
+        "port": 6379,
+        "username": "user",
+        "password": "pass",
+    }
+    with patch("falkordb.asyncio.cluster.RedisCluster") as mock_cluster_cls:
+        Cluster_Conn(mock_conn, ssl=False, read_from_replicas=True)
+        mock_cluster_cls.assert_called_once()
+
+
+def test_async_is_cluster_unix_socket():
+    from redis.asyncio.connection import UnixDomainSocketConnection
+
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = UnixDomainSocketConnection
+    mock_conn.connection_pool.connection_kwargs = {"path": "/tmp/falkordb.sock"}
+    with patch("falkordb.asyncio.cluster.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "cluster"}
+        assert Is_Cluster(mock_conn) is True
+
+
+def test_async_is_cluster_connection_error_raises():
+    from falkordb.asyncio.cluster import Is_Cluster
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 6379}
+    with patch("falkordb.asyncio.cluster.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.side_effect = ConnectionError("failed")
+        with pytest.raises(ConnectionError):
+            Is_Cluster(mock_conn)
+
+
+def test_parse_cluster_slots_edge_cases():
+    raw_slots = [
+        [],  # Empty item
+        [0, 5460],  # Item too short
+        [
+            0,
+            5460,
+            ["127.0.0.1", "6379", "node_primary_1"],  # String types
+            [],  # Empty replica info
+            ["127.0.0.1", 6380],  # Replica without ID
+        ],
+    ]
+    shards = parse_cluster_slots(raw_slots)
+    assert len(shards) == 1
+    assert shards[0]["primary"]["id"] == "node_primary_1"
+    assert shards[0]["replicas"][0]["id"] == "127.0.0.1:6380"

--- a/tests/test_cluster_shards.py
+++ b/tests/test_cluster_shards.py
@@ -1,15 +1,26 @@
 from unittest.mock import MagicMock, patch
+
 import pytest
 
-from falkordb.falkordb import FalkorDB as SyncFalkorDB
 from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
 from falkordb.cluster import parse_cluster_slots
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
 
 
 def test_parse_cluster_slots():
     raw_slots = [
-        [0, 5460, [b"127.0.0.1", 6379, b"node_primary_1"], [b"127.0.0.1", 6380, b"node_replica_1"]],
-        [5461, 10922, [b"127.0.0.1", 6381, b"node_primary_2"], [b"127.0.0.1", 6382, b"node_replica_2"]],
+        [
+            0,
+            5460,
+            [b"127.0.0.1", 6379, b"node_primary_1"],
+            [b"127.0.0.1", 6380, b"node_replica_1"],
+        ],
+        [
+            5461,
+            10922,
+            [b"127.0.0.1", 6381, b"node_primary_2"],
+            [b"127.0.0.1", 6382, b"node_replica_2"],
+        ],
     ]
     shards = parse_cluster_slots(raw_slots)
     assert len(shards) == 2

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -549,3 +549,50 @@ def test_explain(client):
     )
 
     g.delete()
+
+
+def test_schema_cache_on_external_delete(client):
+    g = client
+    gname = g.name
+    db = g.client
+
+    # Phase 1: Build graph A with property order [id, name, color, size]
+    g.query("CREATE (n:Item) SET n.id='i1', n.name='Widget', n.color='red', n.size=10")
+    res = g.query("MATCH (n:Item) RETURN n")
+    assert res.result_set[0][0].properties == {
+        "id": "i1",
+        "name": "Widget",
+        "color": "red",
+        "size": 10,
+    }
+
+    # Phase 2: External delete (raw GRAPH.DELETE, bypassing Graph.delete())
+    db.connection.execute_command("GRAPH.DELETE", gname)
+
+    # Phase 3: Recreate graph B under same name with different
+    # property registration order
+    g_new = db.select_graph(gname)
+    g_new.query(
+        "CREATE (n:Item) SET n.id='i2', n.size=20, n.color='blue', n.name='Gadget'"
+    )
+
+    # Phase 4: Read using existing Graph object and verify compact format
+    # returns correct properties
+    res_compact = g.query("MATCH (n:Item) RETURN n")
+    compact = res_compact.result_set[0][0].properties
+
+    res_map = g.query("MATCH (n:Item) RETURN properties(n)")
+    correct = dict(res_map.result_set[0][0])
+
+    assert (
+        compact
+        == correct
+        == {
+            "id": "i2",
+            "size": 20,
+            "color": "blue",
+            "name": "Gadget",
+        }
+    )
+
+    g_new.delete()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -578,10 +578,10 @@ def test_schema_cache_on_external_delete(client):
 
     # Phase 4: Read using existing Graph object and verify compact format
     # returns correct properties
-    res_compact = g.query("MATCH (n:Item) RETURN n")
+    res_compact = g.ro_query("MATCH (n:Item) RETURN n")
     compact = res_compact.result_set[0][0].properties
 
-    res_map = g.query("MATCH (n:Item) RETURN properties(n)")
+    res_map = g.ro_query("MATCH (n:Item) RETURN properties(n)")
     correct = dict(res_map.result_set[0][0])
 
     assert (

--- a/tests/test_replica_conn.py
+++ b/tests/test_replica_conn.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
+
+
+def test_sync_standalone_get_replica_connection():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    db.connection = mock_conn
+
+    with patch("falkordb.falkordb.Is_Cluster", return_value=False):
+        replica_conn = db.get_replica_connection()
+        assert replica_conn is mock_conn
+
+
+def test_sync_sentinel_get_replica_connection():
+    db = object.__new__(SyncFalkorDB)
+    mock_conn = MagicMock()
+    mock_sentinel = MagicMock()
+    mock_replica_conn = MagicMock()
+    mock_sentinel.replica_for.return_value = mock_replica_conn
+    mock_sentinel.slave_for.return_value = mock_replica_conn
+
+    db.connection = mock_conn
+    db.sentinel = mock_sentinel
+    db.service_name = "mymaster"
+
+    replica_conn = db.get_replica_connection()
+    assert replica_conn is mock_replica_conn
+
+
+def test_sync_sentinel_read_from_replicas_init():
+    mock_redis = MagicMock()
+    mock_sentinel = MagicMock()
+    mock_slave = MagicMock()
+    mock_sentinel.slave_for.return_value = mock_slave
+
+    with patch("falkordb.falkordb.redis.Redis", return_value=mock_redis), patch(
+        "falkordb.falkordb.Is_Sentinel", return_value=True
+    ), patch(
+        "falkordb.falkordb.Sentinel_Conn", return_value=(mock_sentinel, "mymaster")
+    ), patch(
+        "falkordb.falkordb.Is_Cluster", return_value=False
+    ):
+        db = SyncFalkorDB(read_from_replicas=True)
+        assert db.connection is mock_slave
+        mock_sentinel.slave_for.assert_called_once_with("mymaster", ssl=False)
+
+
+def test_sync_cluster_get_replica_connection():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={
+                "host": "127.0.0.1",
+                "port": 6379,
+                "username": None,
+                "password": None,
+            }
+        )
+    )
+    db.connection = mock_conn
+
+    with patch("falkordb.falkordb.Is_Cluster", return_value=True), patch(
+        "falkordb.falkordb.Cluster_Conn"
+    ) as mock_cluster_conn:
+        db.get_replica_connection()
+        mock_cluster_conn.assert_called_once_with(mock_conn, ssl=False, read_from_replicas=True)
+
+
+def test_async_standalone_get_replica_connection():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    db.connection = mock_conn
+
+    with patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=False):
+        replica_conn = db.get_replica_connection()
+        assert replica_conn is mock_conn
+
+
+def test_async_sentinel_get_replica_connection():
+    db = object.__new__(AsyncFalkorDB)
+    mock_conn = MagicMock()
+    mock_sentinel = MagicMock()
+    mock_replica_conn = MagicMock()
+    mock_sentinel.replica_for.return_value = mock_replica_conn
+    mock_sentinel.slave_for.return_value = mock_replica_conn
+
+    db.connection = mock_conn
+    db.sentinel = mock_sentinel
+    db.service_name = "mymaster"
+
+    replica_conn = db.get_replica_connection()
+    assert replica_conn is mock_replica_conn
+
+
+def test_async_sentinel_read_from_replicas_init():
+    mock_redis = MagicMock()
+    mock_sentinel = MagicMock()
+    mock_slave = MagicMock()
+    mock_sentinel.slave_for.return_value = mock_slave
+
+    with patch("falkordb.asyncio.falkordb.redis.Redis", return_value=mock_redis), patch(
+        "falkordb.asyncio.falkordb.Is_Sentinel", return_value=True
+    ), patch(
+        "falkordb.asyncio.falkordb.Sentinel_Conn", return_value=(mock_sentinel, "mymaster")
+    ), patch(
+        "falkordb.asyncio.falkordb.Is_Cluster", return_value=False
+    ):
+        db = AsyncFalkorDB(read_from_replicas=True)
+        assert db.connection is mock_slave
+        mock_sentinel.slave_for.assert_called_once_with("mymaster", ssl=False)
+
+
+def test_async_cluster_get_replica_connection():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = SimpleNamespace(
+        connection_pool=SimpleNamespace(
+            connection_kwargs={
+                "host": "127.0.0.1",
+                "port": 6379,
+                "username": None,
+                "password": None,
+            }
+        )
+    )
+    db.connection = mock_conn
+
+    with patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True), patch(
+        "falkordb.asyncio.falkordb.Cluster_Conn"
+    ) as mock_cluster_conn:
+        db.get_replica_connection()
+        mock_cluster_conn.assert_called_once_with(mock_conn, ssl=False, read_from_replicas=True)

--- a/tests/test_replica_conn.py
+++ b/tests/test_replica_conn.py
@@ -1,8 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
 from falkordb.falkordb import FalkorDB as SyncFalkorDB
 
@@ -41,12 +39,13 @@ def test_sync_sentinel_read_from_replicas_init():
     mock_slave = MagicMock()
     mock_sentinel.slave_for.return_value = mock_slave
 
-    with patch("falkordb.falkordb.redis.Redis", return_value=mock_redis), patch(
-        "falkordb.falkordb.Is_Sentinel", return_value=True
-    ), patch(
-        "falkordb.falkordb.Sentinel_Conn", return_value=(mock_sentinel, "mymaster")
-    ), patch(
-        "falkordb.falkordb.Is_Cluster", return_value=False
+    with (
+        patch("falkordb.falkordb.redis.Redis", return_value=mock_redis),
+        patch("falkordb.falkordb.Is_Sentinel", return_value=True),
+        patch(
+            "falkordb.falkordb.Sentinel_Conn", return_value=(mock_sentinel, "mymaster")
+        ),
+        patch("falkordb.falkordb.Is_Cluster", return_value=False),
     ):
         db = SyncFalkorDB(read_from_replicas=True)
         assert db.connection is mock_slave
@@ -69,11 +68,14 @@ def test_sync_cluster_get_replica_connection():
     )
     db.connection = mock_conn
 
-    with patch("falkordb.falkordb.Is_Cluster", return_value=True), patch(
-        "falkordb.falkordb.Cluster_Conn"
-    ) as mock_cluster_conn:
+    with (
+        patch("falkordb.falkordb.Is_Cluster", return_value=True),
+        patch("falkordb.falkordb.Cluster_Conn") as mock_cluster_conn,
+    ):
         db.get_replica_connection()
-        mock_cluster_conn.assert_called_once_with(mock_conn, ssl=False, read_from_replicas=True)
+        mock_cluster_conn.assert_called_once_with(
+            mock_conn, ssl=False, read_from_replicas=True
+        )
 
 
 def test_async_standalone_get_replica_connection():
@@ -110,12 +112,14 @@ def test_async_sentinel_read_from_replicas_init():
     mock_slave = MagicMock()
     mock_sentinel.slave_for.return_value = mock_slave
 
-    with patch("falkordb.asyncio.falkordb.redis.Redis", return_value=mock_redis), patch(
-        "falkordb.asyncio.falkordb.Is_Sentinel", return_value=True
-    ), patch(
-        "falkordb.asyncio.falkordb.Sentinel_Conn", return_value=(mock_sentinel, "mymaster")
-    ), patch(
-        "falkordb.asyncio.falkordb.Is_Cluster", return_value=False
+    with (
+        patch("falkordb.asyncio.falkordb.redis.Redis", return_value=mock_redis),
+        patch("falkordb.asyncio.falkordb.Is_Sentinel", return_value=True),
+        patch(
+            "falkordb.asyncio.falkordb.Sentinel_Conn",
+            return_value=(mock_sentinel, "mymaster"),
+        ),
+        patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=False),
     ):
         db = AsyncFalkorDB(read_from_replicas=True)
         assert db.connection is mock_slave
@@ -138,8 +142,71 @@ def test_async_cluster_get_replica_connection():
     )
     db.connection = mock_conn
 
-    with patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True), patch(
-        "falkordb.asyncio.falkordb.Cluster_Conn"
-    ) as mock_cluster_conn:
+    with (
+        patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True),
+        patch("falkordb.asyncio.falkordb.Cluster_Conn") as mock_cluster_conn,
+    ):
         db.get_replica_connection()
-        mock_cluster_conn.assert_called_once_with(mock_conn, ssl=False, read_from_replicas=True)
+        mock_cluster_conn.assert_called_once_with(
+            mock_conn, ssl=False, read_from_replicas=True
+        )
+
+
+def test_sync_existing_redis_cluster_get_replica_connection():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    db._raw_conn = MagicMock()
+    db._ssl = False
+    db._replica_connection = None
+
+    cluster_primary = MagicMock(spec=["read_from_replicas"])
+    cluster_primary.read_from_replicas = False
+
+    cluster_replica = MagicMock()
+
+    db.connection = cluster_primary
+
+    with (
+        patch("falkordb.falkordb.Is_Cluster", return_value=True),
+        patch("falkordb.falkordb.isinstance", side_effect=lambda obj, cls: True),
+        patch(
+            "falkordb.falkordb.Cluster_Conn", return_value=cluster_replica
+        ) as mock_cluster_conn,
+    ):
+        replica_conn = db.get_replica_connection()
+        assert replica_conn is cluster_replica
+        mock_cluster_conn.assert_called_once_with(
+            db._raw_conn, ssl=False, read_from_replicas=True
+        )
+
+
+def test_async_existing_redis_cluster_get_replica_connection():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    db._raw_conn = MagicMock()
+    db._ssl = False
+    db._replica_connection = None
+
+    cluster_primary = MagicMock(spec=["read_from_replicas"])
+    cluster_primary.read_from_replicas = False
+
+    cluster_replica = MagicMock()
+
+    db.connection = cluster_primary
+
+    with (
+        patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True),
+        patch(
+            "falkordb.asyncio.falkordb.isinstance", side_effect=lambda obj, cls: True
+        ),
+        patch(
+            "falkordb.asyncio.falkordb.Cluster_Conn", return_value=cluster_replica
+        ) as mock_cluster_conn,
+    ):
+        replica_conn = db.get_replica_connection()
+        assert replica_conn is cluster_replica
+        mock_cluster_conn.assert_called_once_with(
+            db._raw_conn, ssl=False, read_from_replicas=True
+        )

--- a/tests/test_replica_conn.py
+++ b/tests/test_replica_conn.py
@@ -210,3 +210,48 @@ def test_async_existing_redis_cluster_get_replica_connection():
         mock_cluster_conn.assert_called_once_with(
             db._raw_conn, ssl=False, read_from_replicas=True
         )
+
+        # Second call returns cached _replica_connection
+        mock_cluster_conn.reset_mock()
+        assert db.get_replica_connection() is cluster_replica
+        mock_cluster_conn.assert_not_called()
+
+
+def test_sync_redis_cluster_read_from_replicas_true():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    db._raw_conn = MagicMock()
+    db._ssl = False
+
+    cluster_replica = MagicMock(spec=["read_from_replicas"])
+    cluster_replica.read_from_replicas = True
+
+    db.connection = cluster_replica
+
+    with (
+        patch("falkordb.falkordb.Is_Cluster", return_value=True),
+        patch("falkordb.falkordb.isinstance", side_effect=lambda obj, cls: True),
+    ):
+        assert db.get_replica_connection() is cluster_replica
+
+
+def test_async_redis_cluster_read_from_replicas_true():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    db._raw_conn = MagicMock()
+    db._ssl = False
+
+    cluster_replica = MagicMock(spec=["read_from_replicas"])
+    cluster_replica.read_from_replicas = True
+
+    db.connection = cluster_replica
+
+    with (
+        patch("falkordb.asyncio.falkordb.Is_Cluster", return_value=True),
+        patch(
+            "falkordb.asyncio.falkordb.isinstance", side_effect=lambda obj, cls: True
+        ),
+    ):
+        assert db.get_replica_connection() is cluster_replica

--- a/tests/test_sentinel_conn.py
+++ b/tests/test_sentinel_conn.py
@@ -1,0 +1,159 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from falkordb.asyncio.sentinel import (
+    Is_Sentinel as Async_Is_Sentinel,
+)
+from falkordb.asyncio.sentinel import (
+    Sentinel_Conn as Async_Sentinel_Conn,
+)
+from falkordb.sentinel import (
+    Is_Sentinel as Sync_Is_Sentinel,
+)
+from falkordb.sentinel import (
+    Sentinel_Conn as Sync_Sentinel_Conn,
+)
+
+
+def test_sync_is_sentinel_true():
+    mock_conn = MagicMock()
+    mock_conn.info.return_value = {"redis_mode": "sentinel"}
+    assert Sync_Is_Sentinel(mock_conn) is True
+
+
+def test_sync_is_sentinel_false():
+    mock_conn = MagicMock()
+    mock_conn.info.return_value = {"redis_mode": "standalone"}
+    assert Sync_Is_Sentinel(mock_conn) is False
+
+
+def test_sync_is_sentinel_generic_exception():
+    mock_conn = MagicMock()
+    mock_conn.info.side_effect = ValueError("unexpected error")
+    assert Sync_Is_Sentinel(mock_conn) is False
+
+
+def test_sync_is_sentinel_connection_error_raises():
+    mock_conn = MagicMock()
+    mock_conn.info.side_effect = ConnectionError("failed connect")
+    with pytest.raises(ConnectionError):
+        Sync_Is_Sentinel(mock_conn)
+
+
+def test_sync_sentinel_conn_single_master():
+    mock_conn = MagicMock()
+    mock_conn.sentinel_masters.return_value = {"mymaster": {}}
+    mock_conn.connection_pool.connection_kwargs = {
+        "host": "localhost",
+        "port": 26379,
+        "username": "user",
+        "password": "pass",
+    }
+    with patch("falkordb.sentinel.Sentinel") as mock_sentinel_cls:
+        sentinel_inst, service_name = Sync_Sentinel_Conn(mock_conn, ssl=True)
+        assert service_name == "mymaster"
+        mock_sentinel_cls.assert_called_once()
+
+
+def test_sync_sentinel_conn_multiple_masters_raises():
+    mock_conn = MagicMock()
+    mock_conn.sentinel_masters.return_value = {"master1": {}, "master2": {}}
+    with pytest.raises(Exception, match="Multiple masters"):
+        Sync_Sentinel_Conn(mock_conn, ssl=False)
+
+
+def test_async_is_sentinel_true():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 26379}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "sentinel"}
+        assert Async_Is_Sentinel(mock_conn) is True
+
+
+def test_async_is_sentinel_false():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 26379}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "standalone"}
+        assert Async_Is_Sentinel(mock_conn) is False
+
+
+def test_async_is_sentinel_generic_exception():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 26379}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.side_effect = ValueError("error")
+        assert Async_Is_Sentinel(mock_conn) is False
+
+
+def test_async_sentinel_conn_single_master():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {
+        "host": "localhost",
+        "port": 26379,
+        "username": "user",
+        "password": "pass",
+    }
+    with (
+        patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_sync_redis,
+        patch("falkordb.asyncio.sentinel.Sentinel") as mock_async_sentinel_cls,
+    ):
+        mock_sync_redis.return_value.sentinel_masters.return_value = {"mymaster": {}}
+        sentinel_inst, service_name = Async_Sentinel_Conn(mock_conn, ssl=True)
+        assert service_name == "mymaster"
+        mock_async_sentinel_cls.assert_called_once()
+
+
+def test_async_sentinel_conn_multiple_masters_raises():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 26379}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_sync_redis:
+        mock_sync_redis.return_value.sentinel_masters.return_value = {
+            "m1": {},
+            "m2": {},
+        }
+        with pytest.raises(Exception, match="Multiple masters"):
+            Async_Sentinel_Conn(mock_conn, ssl=False)
+
+
+def test_async_is_sentinel_unix_socket():
+    from redis.asyncio.connection import UnixDomainSocketConnection
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = UnixDomainSocketConnection
+    mock_conn.connection_pool.connection_kwargs = {"path": "/tmp/falkordb.sock"}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.return_value = {"redis_mode": "sentinel"}
+        assert Async_Is_Sentinel(mock_conn) is True
+
+
+def test_async_is_sentinel_connection_error_raises():
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = MagicMock()
+    mock_conn.connection_pool.connection_kwargs = {"host": "localhost", "port": 26379}
+    with patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_redis_cls:
+        mock_redis_cls.return_value.info.side_effect = ConnectionError("failed")
+        with pytest.raises(ConnectionError):
+            Async_Is_Sentinel(mock_conn)
+
+
+def test_async_sentinel_conn_unix_socket():
+    from redis.asyncio.connection import UnixDomainSocketConnection
+
+    mock_conn = MagicMock()
+    mock_conn.connection_pool.connection_class = UnixDomainSocketConnection
+    mock_conn.connection_pool.connection_kwargs = {"path": "/tmp/falkordb.sock"}
+    with (
+        patch("falkordb.asyncio.sentinel.sync_redis.Redis") as mock_sync_redis,
+        patch("falkordb.asyncio.sentinel.Sentinel") as mock_async_sentinel_cls,
+    ):
+        mock_sync_redis.return_value.sentinel_masters.return_value = {"mymaster": {}}
+        sentinel_inst, service_name = Async_Sentinel_Conn(mock_conn, ssl=False)
+        assert service_name == "mymaster"
+        mock_async_sentinel_cls.assert_called_once()

--- a/tests/test_timeout_recovery.py
+++ b/tests/test_timeout_recovery.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from redis.exceptions import ResponseError
+
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
+from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+
+
+def test_sync_query_timeout_disconnects_unhealthy_connection():
+    db = object.__new__(SyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+    mock_conn.execute_command.side_effect = [
+        ResponseError("Query timed out"),
+        [["1"]],
+    ]
+    db.connection = mock_conn
+    db.execute_command = mock_conn.execute_command
+
+    graph = db.select_graph("test_timeout_graph")
+
+    # First query triggers query timeout
+    with pytest.raises(ResponseError) as exc_info:
+        graph.query("MATCH (n) RETURN n")
+    assert "Query timed out" in str(exc_info.value)
+
+    # Connection close should have been called to purge dirty socket state
+    mock_conn.close.assert_called_once()
+
+    # Second query succeeds on fresh/reconnected connection without silent C-level crash
+    res = graph.query("RETURN 1")
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_async_query_timeout_disconnects_unhealthy_connection():
+    db = object.__new__(AsyncFalkorDB)
+    db.sentinel = None
+    db.service_name = None
+    mock_conn = MagicMock()
+
+    async def async_exec(*args, **kwargs):
+        if mock_conn.execute_command.call_count == 1:
+            raise ResponseError("Query timed out")
+        return [
+            [[1, b"header"]],
+            [[[3, b"1"]]],
+            [b"Query internal execution time: 0.1 milliseconds"],
+        ]
+
+    mock_conn.execute_command = MagicMock(side_effect=async_exec)
+    mock_conn.aclose = AsyncMock()
+
+    db.connection = mock_conn
+    db.execute_command = mock_conn.execute_command
+
+    graph = db.select_graph("async_test_timeout_graph")
+
+    # First query triggers query timeout
+    with pytest.raises(ResponseError) as exc_info:
+        await graph.query("MATCH (n) RETURN n")
+    assert "Query timed out" in str(exc_info.value)
+
+    # Connection aclose should have been called
+    mock_conn.aclose.assert_called_once()
+
+    # Second query succeeds on fresh connection
+    res = await graph.query("RETURN 1")
+    assert res is not None

--- a/tests/test_timeout_recovery.py
+++ b/tests/test_timeout_recovery.py
@@ -1,9 +1,8 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from redis.exceptions import ResponseError
 
-from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
 from falkordb.falkordb import FalkorDB as SyncFalkorDB
 
 
@@ -31,41 +30,4 @@ def test_sync_query_timeout_disconnects_unhealthy_connection():
 
     # Second query succeeds on fresh/reconnected connection without silent C-level crash
     res = graph.query("RETURN 1")
-    assert res is not None
-
-
-@pytest.mark.asyncio
-async def test_async_query_timeout_disconnects_unhealthy_connection():
-    db = object.__new__(AsyncFalkorDB)
-    db.sentinel = None
-    db.service_name = None
-    mock_conn = MagicMock()
-
-    async def async_exec(*args, **kwargs):
-        if mock_conn.execute_command.call_count == 1:
-            raise ResponseError("Query timed out")
-        return [
-            [[1, b"header"]],
-            [[[3, b"1"]]],
-            [b"Query internal execution time: 0.1 milliseconds"],
-        ]
-
-    mock_conn.execute_command = MagicMock(side_effect=async_exec)
-    mock_conn.aclose = AsyncMock()
-
-    db.connection = mock_conn
-    db.execute_command = mock_conn.execute_command
-
-    graph = db.select_graph("async_test_timeout_graph")
-
-    # First query triggers query timeout
-    with pytest.raises(ResponseError) as exc_info:
-        await graph.query("MATCH (n) RETURN n")
-    assert "Query timed out" in str(exc_info.value)
-
-    # Connection aclose should have been called
-    mock_conn.aclose.assert_called_once()
-
-    # Second query succeeds on fresh connection
-    res = await graph.query("RETURN 1")
     assert res is not None

--- a/tests/test_timeout_recovery.py
+++ b/tests/test_timeout_recovery.py
@@ -1,9 +1,10 @@
 from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from redis.exceptions import ResponseError
 
-from falkordb.falkordb import FalkorDB as SyncFalkorDB
 from falkordb.asyncio.falkordb import FalkorDB as AsyncFalkorDB
+from falkordb.falkordb import FalkorDB as SyncFalkorDB
 
 
 def test_sync_query_timeout_disconnects_unhealthy_connection():


### PR DESCRIPTION
## Summary
- **Replica Connections**: Added `get_replica_connection()` and `read_from_replicas` support for Standalone, Sentinel, and Cluster modes.
- **Cluster Shard Mapping**: Added `get_cluster_shards()` to deduce primary and replica nodes per cluster shard.
- **Query Timeout Recovery**: Implemented dirty socket purging after query timeout errors so subsequent queries do not silently hang or crash.
- **Robust Probing**: Updated `Is_Sentinel` and `Is_Cluster` to safely handle connection errors during node startup and URL initialization.

## Linked Issues
Closes #205
Closes #71

## Test Plan
- Added unit tests in `tests/test_replica_conn.py`, `tests/test_sentinel_conn.py`, `tests/test_cluster_shards.py`, and `tests/test_timeout_recovery.py`.
- 100% Codecov coverage on all new/modified files.
- All 44 unit tests and Ruff formatting/linter checks pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Redis Cluster and Sentinel connections.
  * Added replica-aware connection selection and cluster shard discovery.
* **Bug Fixes**
  * Improved schema cache refresh after graph changes or recreation.
  * Query timeouts now safely reset unhealthy connections, allowing subsequent queries to succeed.
  * Improved connection cleanup during shutdown and recovery.
* **Tests**
  * Added coverage for cluster sharding, Sentinel connections, replica selection, schema refreshes, and timeout recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->