### PR TITLE
ci: alert on a cancelled scheduled run, not just a failed one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: falkordb-version
 
+    # Without this the job inherits the 6 hour default, so a hung suite holds a
+    # runner all morning and then reports `cancelled` rather than failing.
+    timeout-minutes: 30
+
     services:
       falkordb:
         # Docker Hub image, tag resolved by the `falkordb-version` job above.
@@ -92,7 +96,10 @@ jobs:
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [falkordb-version, test]
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    # `cancelled` as well as `failure`: a job stopped by its own timeout, or one
+    # that ran into GitHub's six hour ceiling, reports `cancelled`, and a nightly
+    # that hangs is exactly the case this alert exists for.
+    if: ${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: write
     # Pinned, and only the one secret it declares is passed: a mutable ref


### PR DESCRIPTION
The daily `edge` run is our early warning for engine changes, but the alert
that reports it never fires when the run hangs.

`report-scheduled-failure` is gated on:

```yaml
if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
```

A job stopped by a timeout, or by GitHub's six hour ceiling, reports
`cancelled`, not `failure`. So the alert is skipped in exactly the case it
exists for. This adds `cancelled` to the condition.

It also caps the job at `timeout-minutes: 30`. Recent nightlies finish in
about two minutes, so anything near the cap is stuck, and failing at 30
minutes reports a result the same morning instead of holding a runner until
the six hour ceiling.

The `github.event_name == 'schedule'` guard stays, so a force push that
cancels an in flight PR run still does not raise an alert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a 30-minute timeout to automated test runs.
  * Improved scheduled failure reporting when prerequisite jobs fail, are cancelled, or time out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->